### PR TITLE
fix(deps): switch to ansible-core for Python 3.14 compatibility

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-ansible>=13.3,<14
+ansible-core>=2.20.0
 ansible-lint>=24.0
 yamllint>=1.33
 molecule>=24.0


### PR DESCRIPTION
## Summary

- Replace `ansible>=13.3,<14` meta-package with `ansible-core>=2.20.0` in `requirements-dev.txt`
- The `ansible` meta-package 13.x bundles `ansible-core` 2.17.x, which doesn't support Python 3.14
- Collections are already installed separately via `requirements.yml`, so the bundled collections were redundant

Fixes #26

## Test plan

- [ ] CI lint workflow passes (ansible-lint, yamllint, syntax check) on Python 3.14
- [ ] `ansible --version` shows 2.20.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)