### PR TITLE
Add Claude Code agent definitions and memory

### DIFF
--- a/.claude/agent-memory/ansible-reviewer/review-findings.md
+++ b/.claude/agent-memory/ansible-reviewer/review-findings.md
@@ -1,0 +1,227 @@
+# Review Findings
+
+## feat/multi-ssh-keys Review (2026-02-10, 7 commits)
+
+### Scope
+Decouples VM hostname from Proxmox display name (mms_vm_hostname vs mms_vm_name), adds multi-SSH-key
+support, fixes INI loop_var collision in quadlet_service, adds Tmpfs=/run:U to container.j2 for
+s6-overlay compat, switches Jellyfin to official image, adds per-service tmpfs and configurable
+NoNewPrivileges to container template, wraps mms-services.sh in {% raw %} block.
+
+### Findings
+- MEDIUM: Immich templates (4 files) missing Tmpfs=/run:U, diverging from generic container.j2
+- MEDIUM: NoNewPrivileges uses `| lower` without `| bool` normalization (fragile for non-bool inputs)
+- LOW: Jellyfin tmpfs /cache may need :U flag for correct rootless ownership
+- LOW: sshkeys join('\n') -- Jinja2 single-quote escape behavior needs end-to-end validation
+- LOW: Jellyfin health_cmd relies on curl presence in official image (acceptable, but document)
+
+### Positive patterns
+- mms_vm_hostname/mms_vm_name split is clean, fully propagated, well-scoped
+- Old mms_vm_ssh_pubkey (singular) fully cleaned up, no stale references
+- loop_var: ini_setting prevents real collision bug in outer-loop contexts
+- Tmpfs=/run:U is correct fix for rootless Podman with s6-overlay preinit
+- Configurable no_new_privileges is forward-looking (some containers need it off)
+- Per-service tmpfs list is a good data-driven extension
+- {% raw %} block correctly protects bash variable syntax from Jinja2
+- Molecule fixture updated for mms_vm_hostname rename
+- no_log: true on cloud-init task (resolves prior review item #11)
+- Proxmox infra values updated (API host, node, storage names)
+
+### Items resolved from prior reviews
+- proxmox_vm cloud-init task now has no_log: true (was #11)
+
+---
+
+## mms-services Maintenance Script Review (fix/sabnzbd-host-whitelist, 2026-02-10)
+
+### Scope
+New mms-services shell script template deployed to ~/bin/ by base_system role. Discovers Quadlet
+container services dynamically, manages start/stop with tier-based dependency ordering
+(infra -> immich-app -> app -> proxy). Added base_system_home default and two deploy tasks.
+
+### Findings
+- HIGH: base_system Molecule host_vars missing mms_home and mms_quadlet_dir (converge will fail)
+- MEDIUM: do_action swallows systemctl failures (exits 0 even when services fail)
+- MEDIUM: 2>/dev/null on systemctl hides diagnostic error messages
+- LOW: become: true on new tasks is redundant (play already sets become: true)
+- LOW: "${action}ing" produces "stoping" (bad gerund)
+- LOW: Tier categorization hard-coded in script (acceptable for homelab scale)
+- LOW: base_system_home variable placed out of logical order in defaults
+
+### Positive patterns
+- Dynamic service discovery from .container files (no hard-coded service list)
+- set -euo pipefail in generated script
+- Template src path follows established {{ playbook_dir }}/../templates/ convention
+- base_system_home correctly wraps mms_home through role indirection
+- Task ordering correct: user create -> bin dir -> script deploy -> linger enable
+- Both Ansible tasks are fully idempotent (file module + template module)
+
+---
+
+## Per-Group Autodeploy Schedules Review (feat/renovate-autodeploy, 2026-02-09)
+
+### Scope
+Evolves single autodeploy timer into per-group model. Each group gets own systemd timer+service
+pair with independent schedule and optional service filter. Shared lock prevents concurrent deploys.
+deploy-services.yml gains optional deploy_services filtering. Legacy single-unit files cleaned up.
+
+### Findings
+- MEDIUM: Stale per-group units deleted without stop/disable (running timer persists in memory)
+- MEDIUM: _deploy_immich/_deploy_traefik use >- folding (string-as-boolean, saved by | bool)
+- LOW: _expected_timer_files set_fact is dead code (never referenced)
+- LOW: autodeploy_groups in group_vars lacks mms_ prefix (intentional but breaks convention)
+- LOW: No validation that group dicts contain required 'schedule' key
+- LOW: Group names not validated for safe use in filenames/bash
+
+### Positive patterns
+- Shared lock across groups prevents concurrent deploys on shared git repo
+- Per-group state files and marker-based Galaxy dedup are well-designed
+- Legacy cleanup properly stops/disables before removing (good pattern)
+- intersect filter in deploy-services.yml prevents deploying unknown services
+- Handler loop over dict2items correctly enables all group timers
+- blockinfile for SSH config (fixes prior review item #15)
+- After=network-online.target added to service template (fixes prior review item #18)
+
+### Items resolved from prior reviews
+- SSH config now uses blockinfile (was #15)
+- Script uses {{ inventory_hostname }} not $(hostname) (was #16)
+- Service unit has After=network-online.target (was #18)
+
+---
+
+## Autodeploy + Renovate Review (main, 2026-02-09)
+
+### Scope
+New autodeploy role (git poll + systemd timer), Renovate config for automated version PRs,
+removal of podman auto-update (AutoUpdate=registry from Immich, update-services.yml deleted),
+pinned Galaxy collection versions, simplified traefik image variable, Immich renovate annotation.
+
+### Findings
+- HIGH: NOPASSWD:ALL sudoers for mms user is overly broad (required for Ansible become mechanism)
+- HIGH: SSH config task overwrites entire ~/.ssh/config (should use blockinfile)
+- MEDIUM: $(hostname) in deploy script may not match inventory hostname mms-vm
+- MEDIUM: ansible-galaxy install --force always runs with changed_when: false (hides real state)
+- MEDIUM: CLAUDE.md and README.md still reference deleted update-services.yml
+- MEDIUM: No validation that autodeploy_repo_url is set (timer will silently fail)
+- LOW: systemd service missing After=network-online.target (has Wants but not After)
+- LOW: Lock file in /tmp is world-writable (DoS risk, tmpfiles.d cleanup risk)
+- LOW: Stale lock recovery has minor race condition between rmdir and mkdir
+- LOW: Traefik image variable lost mms_ override capability (OK since Renovate manages it)
+
+### Positive patterns
+- Role structure follows backup role pattern closely (clean, consistent)
+- Atomic lock via mkdir, stale lock detection, log rotation
+- Conditional Galaxy update in script (only when requirements.yml changes)
+- Secrets handling: no_log on SSH key and vault password, guarded by is defined
+- Renovate config well-structured: 4 custom managers, sensible auto-merge policy
+- AutoUpdate=registry correctly removed from Immich (was conflicting with pinned versions)
+
+---
+
+## fix/dry-run-issues Review (2026-02-08, 14 commits)
+
+### Scope
+Branch adds: Fedora cloud template creation, Proxmox API token fix, UID/GID change to 3000,
+SELinux boolean change to virt_use_nfs, registries.conf regex fix, ContainerName in quadlet,
+tailscale serve --bg, Immich ML python healthcheck, Immich secret via env var + printf,
+dnf clean all + cloud-init wait, storage role become_user, VLAN support.
+
+### Findings
+- HIGH: dnf clean all unconditional, always changed (non-idempotent, noisy)
+- HIGH: _template_exists is string "True"/"False", `not` works by accident (same as _immich_secret_needs_update)
+- MEDIUM: Template creation has no partial-failure recovery (block/rescue recommended)
+- MEDIUM: Molecule fixtures still use UID/GID 1100 (should be 3000)
+- MEDIUM: Storage NFS dir tasks lost owner/group/mode, relies on NFS server config (implicit assumption)
+- MEDIUM: CLAUDE.md and memory files reference container_use_nfs but code uses virt_use_nfs
+- LOW: tailscale serve failed_when: false swallows all errors
+- LOW: Template cleanup only runs when template didn't exist; stale files possible
+- LOW: cloud-init wait has failed_when: false without explanatory comment
+- LOW: Proxmox API params repeated 6 times in proxmox_vm role
+
+### Positive changes
+- API token_id/api_user split correctly resolves Proxmox auth
+- vmid/newid clone semantics fixed
+- Variable scoping (group_vars/all) solves cross-group access
+- Immich secret via env var is more secure than stdin
+- Python healthcheck removes curl dependency from ML image
+- tailscale serve --bg prevents blocking
+- ContainerName gives stable DNS names in Podman network
+
+---
+
+## fix/bug-fix-branch Review (2026-02-08, 15 commits)
+
+### Addressed from initial review
+- Immich secret create now has no_log: true (was missing)
+- Restore.yml duplication extracted into restore_service.yml
+- Dead backup task files removed (arr.yml, jellyfin.yml, etc.)
+- Retention logic replaced with proper GFS in shell script
+- Podman package moved from base_system to podman role (no longer installed twice)
+
+### New findings (this branch)
+- HIGH: restore_service.yml missing become/become_user/environment for rootless systemd stop/start
+- HIGH: _immich_secret_needs_update uses >- folding, produces string "True"/"False" not bool; when conditions may misbehave
+- MEDIUM: AutoUpdate=registry in container.j2 conflicts with pinned image versions
+- MEDIUM: quadlet_service Molecule test missing mms_network_name variable (converge will fail)
+- MEDIUM: CI yamllint step missing -c .yamllint.yml (uses default config, not project config)
+- MEDIUM: .ansible-lint suppresses no-changed-when globally (should be targeted)
+- LOW: restore_service.yml decrypt task missing changed_when
+- LOW: Backup script uses grep -oP (PCRE) -- works on Fedora but not universally portable
+
+### Still open from initial review
+- immich.env.j2: DB_PASSWORD no longer in plaintext (uses Secret=), but env file still has no password field -- RESOLVED
+- Service definitions still hard-code /home/mms paths -- NOT addressed
+- Network quadlet still deployed in both podman role and deploy-services -- NOT addressed on this branch
+
+---
+
+## feat/add-traefik-proxy Full Review (2026-02-09, 9 commits)
+
+### Scope
+Adds Traefik reverse proxy role, removes per-service port publishing, removes Tailscale serve
+mappings, adds pre-pull image pattern to quadlet_service/immich, adds cloud-init password for
+VM console access, adds VM description with service links, bumps RAM to 16GB, updates docs.
+
+### Findings
+- HIGH: proxmox_vm cloud-init task passes cipassword with no no_log (password exposed in output)
+- MEDIUM: Traefik AutoUpdate=registry conflicts with pinned image (v3.3); proxy outage if bad update
+- MEDIUM: tailscale serve reset runs unconditionally with no guard; will silently wipe future manual config
+- MEDIUM: mms_traefik_domain has real domain (media.drc.nz) in group_vars/all (fine for private repo)
+- LOW: Dynamic config task does not notify handler (correct: watch: true picks it up, and start task covers cold start)
+- LOW: No Molecule test for traefik role yet
+
+### Positive patterns
+- File provider avoids socket mount (security win)
+- Clean separation: static config + dynamic config + quadlet
+- Handlers follow established project pattern (daemon_reload + restart + become/env)
+- container.j2 publish_ports conditional is correct and backward-compatible
+- Pre-pull image pattern in quadlet_service and immich prevents systemd timeout on first boot
+- First-boot health timeout (300s vs 120s) is a good operational improvement
+- Tailscale serve cleanup is safe (file removal + reset)
+- Comprehensive documentation updates in README, CLAUDE.md
+- immich_port dead variable was cleaned up (removed from defaults)
+- Dynamic config no longer notifies restart (fixed from earlier review; watch: true is correct approach)
+
+---
+
+## Initial Implementation Review (feat/initial-implementation, 2026-02-07, 13 commits)
+
+### High-priority
+- immich.env.j2 line 7: DB_PASSWORD in plaintext env file AND Secret= in quadlet (conflicting, password exposed in .env)
+- Immich secret create tasks missing no_log: true (password appears in logs)
+- Service definitions hard-code /home/mms paths instead of using {{ mms_home }}/{{ mms_config_dir }}
+- restore.yml: massive code duplication, all command tasks lack idempotence guards
+- Backup Ansible tasks (arr.yml, jellyfin.yml etc.) duplicate logic in mms-backup.sh.j2 script
+
+### Medium-priority
+- Network quadlet deployed in podman role AND deploy-services.yml (will always show changed on second)
+- Retention logic in retention.yml calculates daily/weekly cutoffs but only deletes by monthly
+- base_system handlers/main.yml has sysctl handler that is never notified
+- deploy-services.yml has inline tasks for network that should be in a role or pre_tasks
+- become: true at ansible.cfg level means ALL plays escalate; provision-vm.yml runs as root on localhost unnecessarily
+
+### Low-priority
+- Container health_cmd uses curl but LinuxServer images may not have curl (busybox wget instead)
+- backup_age_identity_file referenced in restore.yml but never defined in defaults
+- Tailscale serve script idempotence: checks port in status output but serve --https syntax may not match
+- podman role packages already listed in base_system_packages (podman installed twice)

--- a/.claude/agent-memory/markdown-doc-reviewer/MEMORY.md
+++ b/.claude/agent-memory/markdown-doc-reviewer/MEMORY.md
@@ -1,0 +1,83 @@
+# MMS Documentation Reviewer Memory
+
+## Document Inventory
+- `CLAUDE.md` -- Developer onboarding / AI assistant context (68 lines)
+- `README.md` -- Full project README with architecture, Quick Start, operations, Proxmox setup, Traefik, age encryption, Auto-Deploy (~600 lines)
+- `.claude/agents/ansible-reviewer.md` -- Ansible review agent definition
+- `.claude/agents/supply-chain-hygiene-reviewer.md` -- Supply-chain review agent definition
+- `.claude/agents/markdown-doc-reviewer.md` -- This agent's definition
+
+## Terminology Conventions
+- "Rootless Podman" (capitalized)
+- "Quadlet" (capitalized when referring to the systemd integration)
+- "mms" (lowercase when referring to the user/service name)
+- SELinux boolean: `virt_use_nfs` (NOT `container_use_nfs` -- fixed in commit a222f8c)
+- Variable prefixes: `mms_` (global), `vault_` (secrets)
+- Heading style: sentence case in both CLAUDE.md and README.md
+- List markers: `-` consistently
+- Code blocks: `bash` for shell, `yaml` for YAML, bare fence for ASCII art
+
+## Known Documentation Gaps (as of 2026-02-10)
+- No CHANGELOG documenting the UID/GID change from 1100 to 3000
+- No migration guide for existing deployments
+- Fedora version (43) not mentioned in prose of CLAUDE.md or README.md (only in inventory)
+- No LICENSE or CONTRIBUTING files (acceptable for personal homelab)
+- ~~README line 106 lists `vault_backup_age_public_key`~~ RESOLVED: now correctly uses `mms_backup_age_public_key`
+- Dead variable `immich_port` in roles/immich/defaults/main.yml (no longer published)
+- ~~CLAUDE.md roles list missing `autodeploy` role~~ RESOLVED: autodeploy now listed
+- ~~CLAUDE.md Architecture section missing auto-deploy/Renovate bullet~~ RESOLVED: auto-deploy bullet present
+- CLAUDE.md Conventions missing: `mms_vm_hostname`/`mms_vm_name` split, `mms_vm_ssh_pubkeys` list, `Tmpfs=/run:U`, per-service `tmpfs`, `NoNewPrivileges`, Jellyfin official image
+- README Quick Start step 2 file descriptions stale (VM specs/SSH keys moved to group_vars/all)
+- supply-chain-hygiene-reviewer.md services list missing Channels DVR and Navidrome
+
+## Source of Truth for Key Values
+- UID/GID: `inventory/group_vars/all/vars.yml` lines 23-25 (currently 3000:3000)
+- VM hostname: `inventory/group_vars/all/vars.yml` line 6 (`mms_vm_hostname`)
+- VM display name: `inventory/group_vars/proxmox/vars.yml` line 18 (`mms_vm_name`)
+- SSH public keys: `inventory/group_vars/all/vars.yml` lines 18-20 (`mms_vm_ssh_pubkeys` -- list)
+- Traefik domain: `inventory/group_vars/all/vars.yml` line 50 (`mms_traefik_domain`)
+- SELinux boolean: `roles/base_system/defaults/main.yml` line 20 (`virt_use_nfs`)
+- Fedora version: `inventory/group_vars/proxmox/vars.yml` line 14 (Fedora 43)
+- Services list: `inventory/group_vars/mms/vars.yml` lines 25-33
+- Traefik routes: `inventory/group_vars/mms/vars.yml` lines 36-72 (`mms_traefik_routes`)
+- Traefik role defaults: `roles/traefik/defaults/main.yml` (image, port 80, log level)
+- Autodeploy defaults: `roles/autodeploy/defaults/main.yml` (groups, branch, timeout, retention)
+- Autodeploy inventory override: `inventory/group_vars/mms/vars.yml` lines 74-94 (repo URL, groups)
+- Jellyfin image: `services/jellyfin.yml` (`docker.io/jellyfin/jellyfin`, no PUID/PGID)
+- Container template: `templates/quadlet/container.j2` (Tmpfs=/run:U, per-service tmpfs, NoNewPrivileges)
+- Playbook names: `playbooks/` directory
+
+## Review History
+- 2026-02-08: Full review of all .md files on fix/dry-run-issues branch (15 commits over main)
+  - Found 3 files with stale UID 1100 (CLAUDE.md, README.md, supply-chain-hygiene-reviewer.md)
+  - Found 1 missed Molecule fixture (testapp.yml PUID/PGID still 1100)
+  - Found 1 stale ansible-reviewer memory entry (item #10 re: container_use_nfs)
+  - SELinux boolean in CLAUDE.md already correctly says virt_use_nfs
+  - README structure is comprehensive and well-organized
+  - See review-findings.md for details
+- 2026-02-08: Review of CLAUDE.md + README.md on feat/add-traefik-proxy branch
+  - Traefik integration well-documented: architecture diagram, DNS setup, config, verification
+  - No stale tailscale serve or port-publishing references in docs
+  - tailscale role code correctly cleans up legacy serve (lines 44-52)
+  - ASCII diagram line 32 is 1 char too wide (formatting bug)
+  - README line 106: stale `vault_backup_age_public_key` (pre-existing, not Traefik-related)
+  - CLAUDE.md missing `mms_traefik_domain`/`mms_traefik_routes` in Conventions section
+- 2026-02-09: Review of Auto-Deploy section on feat/renovate-autodeploy branch
+  - Per-group `autodeploy_groups` feature well-documented with examples
+  - Variable table matches role defaults exactly
+  - deploy-services.yml `deploy_services` filtering logic verified correct
+  - Grammar fix needed on line 531 ("for that group's timer fires")
+  - CLAUDE.md needs autodeploy role added to roles list and Architecture section
+  - Autodeploy variable naming (bare vs mms_ prefix) could use a clarifying note
+  - Missing troubleshooting/rollback/disable guidance (backlog items)
+  - See review-findings.md for details
+- 2026-02-10: Full review of all .md files on feat/multi-ssh-keys branch (9 commits over main)
+  - `mms_vm_hostname`/`mms_vm_name` split not documented in CLAUDE.md or README.md
+  - `mms_vm_ssh_pubkeys` (list) not reflected in README Quick Start (still says singular "SSH public key")
+  - README Quick Start step 2 file descriptions stale (VM specs moved to group_vars/all)
+  - CLAUDE.md Conventions missing: variable split, SSH keys list, Tmpfs/NoNewPrivileges, Jellyfin image
+  - supply-chain-hygiene-reviewer.md missing Channels DVR and Navidrome
+  - CLAUDE.md roles list now correctly includes autodeploy (prior gap resolved)
+  - README backup variable name now correct (`mms_backup_age_public_key`, prior gap resolved)
+  - Immich templates all have Tmpfs=/run:U (prior ansible-reviewer item #27 resolved)
+  - See review-findings.md for details

--- a/.claude/agent-memory/markdown-doc-reviewer/review-findings.md
+++ b/.claude/agent-memory/markdown-doc-reviewer/review-findings.md
@@ -1,0 +1,170 @@
+# Review Findings
+
+## feat/multi-ssh-keys Branch Review (2026-02-10)
+
+### Scope
+All .md files in the repository, cross-referenced against codebase on feat/multi-ssh-keys branch (9 commits over main). Key changes: mms_vm_hostname/mms_vm_name split, multi-SSH-key support, Tmpfs=/run:U in container template + Immich templates, per-service tmpfs, configurable NoNewPrivileges, Jellyfin official image, INI loop_var fix.
+
+### Files Reviewed
+- CLAUDE.md (67 lines)
+- README.md (615 lines)
+- .claude/agents/supply-chain-hygiene-reviewer.md (185 lines)
+- .claude/agents/ansible-reviewer.md (185 lines)
+- .claude/agent-memory/ansible-reviewer/MEMORY.md (115 lines)
+- .claude/agent-memory/ansible-reviewer/review-findings.md (228 lines)
+- inventory/group_vars/all/vars.yml (66 lines)
+- inventory/group_vars/proxmox/vars.yml (19 lines)
+- inventory/group_vars/mms/vars.yml (95 lines)
+- templates/quadlet/container.j2 (53 lines)
+- services/jellyfin.yml (17 lines)
+- roles/proxmox_vm/defaults/main.yml (35 lines)
+- roles/proxmox_vm/tasks/main.yml (101 lines)
+- roles/base_system/defaults/main.yml (26 lines)
+- roles/tailscale/defaults/main.yml (6 lines)
+- roles/quadlet_service/tasks/main.yml (129 lines)
+- roles/immich/templates/ (4 .container.j2 files)
+
+### Findings
+- HIGH: README.md:71 says "SSH public key" (singular) and points to group_vars/mms; keys are now a list in group_vars/all
+- HIGH: README.md:70-72 Quick Start step 2 file descriptions are stale (VM specs and SSH keys moved from mms to all)
+- HIGH: CLAUDE.md missing mms_vm_hostname/mms_vm_name split in Conventions (key architectural decision)
+- MEDIUM: CLAUDE.md Conventions missing Tmpfs=/run:U, per-service tmpfs, configurable NoNewPrivileges
+- MEDIUM: CLAUDE.md Conventions missing Jellyfin official image note (no PUID/PGID)
+- MEDIUM: supply-chain-hygiene-reviewer.md:19 services list missing Channels DVR and Navidrome
+
+### Previously Flagged Issues Now Resolved
+- README vault_backup_age_public_key -> now correctly mms_backup_age_public_key
+- CLAUDE.md roles list now includes autodeploy
+- CLAUDE.md Architecture section now has auto-deploy/Renovate bullet
+- Immich templates now have Tmpfs=/run:U (ansible-reviewer item #27)
+- sshkeys join('\n') replaced with YAML block scalar (ansible-reviewer item #30)
+- Jellyfin /cache tmpfs has :U flag (ansible-reviewer item #29)
+- CLAUDE.md Conventions now includes Traefik routing line
+
+### Verified Accurate
+- CLAUDE.md Key Commands: all 8 playbook commands match filesystem (site, deploy-service, deploy-services, backup, restore, migrate, provision-vm, setup-base)
+- CLAUDE.md Repository Layout: all directories match; roles list includes all 12 roles including autodeploy
+- CLAUDE.md Architecture: 6 bullets accurate (Rootless Podman, data-driven, Traefik, Immich, Secrets, Auto-deploy)
+- CLAUDE.md Access line: correctly says Traefik reverse proxy on port 80
+- README.md Services table: 9 services with correct subdomain URLs match mms_traefik_routes
+- README.md Architecture diagram: UID/GID correctly 3000:3000, traefik as entry point
+- README.md Proxmox API Token Setup: SDN.Use correctly added with explanation and permission command
+- README.md Auto-Deploy section: all accurate (config table, examples, vault vars)
+- README.md Traefik, Backup, Restore, Security sections: all accurate
+- UID/GID consistently 3000:3000 across all docs
+- No stale references to update-services.yml in any doc
+- No stale references to LSIO/linuxserver in any doc
+- container.j2 template: Tmpfs=/run:U present, per-service tmpfs loop present, NoNewPrivileges configurable
+- All 4 Immich container templates have Tmpfs=/run:U
+- Jellyfin service definition: official image, /cache:U tmpfs, no PUID/PGID
+- base_system defaults: hostname from mms_vm_hostname (line 7)
+- tailscale defaults: hostname from mms_vm_hostname (line 2)
+- proxmox_vm defaults: name from mms_vm_name (line 14)
+- proxmox_vm tasks: sshkeys uses YAML block scalar with for loop (lines 59-62)
+- quadlet_service tasks: INI loop uses loop_var: ini_setting (line 125)
+
+---
+
+## fix/dry-run-issues Branch Review (2026-02-08)
+
+### Scope
+All .md files in the repository, cross-referenced against codebase on fix/dry-run-issues branch (15 commits over main).
+
+### Files Reviewed
+- CLAUDE.md (67 lines)
+- README.md (378 lines)
+- .claude/agents/supply-chain-hygiene-reviewer.md (185 lines)
+- .claude/agents/ansible-reviewer.md (185 lines)
+- .claude/agent-memory/ansible-reviewer/MEMORY.md (73 lines)
+- .claude/agent-memory/ansible-reviewer/review-findings.md (81 lines)
+
+### Findings
+- HIGH: CLAUDE.md:47 says UID 1100:1100, inventory says 3000:3000
+- HIGH: README.md:25 ASCII diagram says 1100:1100, should be 3000:3000
+- MEDIUM: supply-chain-hygiene-reviewer.md:18 says 1100:1100, should be 3000:3000
+- MEDIUM: ansible-reviewer MEMORY.md item #10 claims container_use_nfs unfixed, but a222f8c fixed it
+- MEDIUM: testapp.yml molecule fixture missed by a222f8c (PUID/PGID still 1100)
+- LOW: Fedora version not stated in CLAUDE.md or README.md prose
+- LOW: No CHANGELOG for breaking UID/GID change
+
+### Verified Accurate
+- CLAUDE.md Key Commands: all playbook paths match filesystem
+- CLAUDE.md Repository Layout: all directories and roles match
+- CLAUDE.md Conventions: SELinux boolean correctly says virt_use_nfs
+- README.md Services table: ports match service definitions
+- README.md Prerequisites: includes SSH root access (commit 09e318e)
+- README.md Quick Start commands: all playbook names exist
+- README.md Storage Layout: matches TRaSH Guides pattern
+- README.md "Adding a New Service": references correct files and variable names
+
+## feat/add-traefik-proxy Branch Review (2026-02-08)
+
+### Scope
+CLAUDE.md (68 lines) and README.md (430 lines) on feat/add-traefik-proxy branch, cross-referenced against traefik role, inventory, service definitions, and tailscale role.
+
+### Findings
+- MEDIUM: README.md:32 ASCII diagram line is 61 chars (should be 60, one extra space)
+- MEDIUM: README.md:106 lists `vault_backup_age_public_key` (doesn't exist); actual var is `mms_backup_age_public_key` in vars.yml
+- LOW: CLAUDE.md Conventions section does not mention `mms_traefik_domain` or `mms_traefik_routes`
+- LOW: README.md Traefik section missing redeployment instructions after route changes
+- LOW: README.md "Adding a New Service" missing DNS reminder
+- LOW: ansible-reviewer MEMORY.md:26 still describes tailscale serve mappings (stale)
+- LOW: Dead variable `immich_port` in roles/immich/defaults/main.yml (never used in templates)
+
+### Verified Accurate
+- CLAUDE.md Access line: correctly says "Traefik reverse proxy on port 80, Tailscale only"
+- CLAUDE.md Architecture: includes Traefik bullet with file provider and mms_traefik_routes
+- CLAUDE.md Roles list: includes traefik role
+- README.md Architecture diagram: correctly shows traefik (:80) as single entry point
+- README.md Traefik section: DNS setup, configuration, verification all accurate
+- README.md Security section: correctly describes no socket mount, HTTP-only rationale
+- README.md Services table URLs: match mms_traefik_routes subdomains + mms_traefik_domain
+- Traefik dynamic template: routes match mms_traefik_routes structure documented in README
+- Tailscale role: correctly cleans up legacy serve config (lines 44-52)
+- No service definitions have publish_ports (confirmed: all 6 service YAML files checked)
+- Immich server container template: no PublishPort directive
+- deploy-services.yml: traefik role deployed last (after quadlet_service and immich)
+- Collections in requirements.yml match README Prerequisites
+
+## feat/renovate-autodeploy Branch Review (2026-02-09)
+
+### Scope
+Auto-Deploy section of README.md (lines 361-532) and CLAUDE.md on feat/renovate-autodeploy branch, cross-referenced against autodeploy role (defaults, tasks, templates, handlers), deploy-services.yml playbook, renovate.json5, and inventory vars.
+
+### Files Reviewed
+- README.md (~600 lines, focused on lines 361-532)
+- CLAUDE.md (68 lines)
+- roles/autodeploy/defaults/main.yml (18 lines)
+- roles/autodeploy/tasks/main.yml (227 lines)
+- roles/autodeploy/templates/mms-autodeploy.sh.j2 (119 lines)
+- roles/autodeploy/templates/mms-autodeploy.service.j2 (15 lines)
+- roles/autodeploy/templates/mms-autodeploy.timer.j2 (12 lines)
+- roles/autodeploy/handlers/main.yml (22 lines)
+- playbooks/deploy-services.yml (36 lines)
+- renovate.json5 (75 lines)
+- inventory/group_vars/mms/vars.yml (80 lines)
+
+### Findings
+- MEDIUM: CLAUDE.md:54 roles list missing `autodeploy`
+- MEDIUM: CLAUDE.md Architecture section has no auto-deploy/Renovate bullet
+- MEDIUM: README.md:486-494 variable table uses bare role default names but `autodeploy_repo_url` derives from `mms_autodeploy_repo_url`; naming relationship not explained
+- LOW: README.md:531 grammar: "for that group's timer fires" -> "when the group's timer fires"
+- LOW: README.md:498-500 no mention of RandomizedDelaySec=60 timer jitter
+- LOW: No troubleshooting, rollback, or disable guidance for auto-deploy
+
+### Verified Accurate
+- Configuration table variable names and defaults match roles/autodeploy/defaults/main.yml exactly
+- `autodeploy_groups` default (single group, 30-min schedule) matches code
+- Two-group example matches actual inventory at inventory/group_vars/mms/vars.yml:65-79
+- deploy-services.yml `deploy_services` variable filtering logic correctly handles both omitted and specified services
+- Immich and Traefik are correctly handled as special cases in deploy-services.yml (lines 15-18, 27-35)
+- Script template correctly passes `deploy_services` as JSON via `-e` flag (line 93)
+- Shared lock file across groups confirmed in script (mkdir-based atomic lock)
+- Per-group state file tracking confirmed (STATE_FILE="${STATE_DIR}/last-deployed-${GROUP}")
+- Stale lock detection confirmed (compares lock age to TIMEOUT)
+- Galaxy collection dedup across groups confirmed (REQS_MARKER mechanism)
+- Vault variables (`vault_autodeploy_ssh_key`, `vault_mms_vault_password`) match tasks/main.yml usage
+- setup-base.yml includes autodeploy role (line 11)
+- renovate.json5 package rules match README description (auto-merge patch/minor, manual major)
+- renovate.json5 grouping matches README (LinuxServer, Immich, Galaxy)
+- Legacy single-unit cleanup present in tasks (lines 122-151)

--- a/.claude/agents/ansible-reviewer.md
+++ b/.claude/agents/ansible-reviewer.md
@@ -1,0 +1,184 @@
+---
+name: ansible-reviewer
+description: "Use this agent when Ansible playbooks, roles, inventories, group/host vars, templates, or ansible.cfg files have been written or modified and need review. This includes reviewing newly created roles, refactored playbooks, inventory restructuring, or any Ansible automation content for correctness, safety, idempotence, and best practices.\\n\\nExamples:\\n\\n- Example 1:\\n  user: \"I just wrote a new role to deploy PostgreSQL with pgvector on our Proxmox VMs\"\\n  assistant: \"Let me review the role structure and tasks for you.\"\\n  <commentary>\\n  Since Ansible role content was written, use the Task tool to launch the ansible-reviewer agent to review the role for idempotence, safety, structure, secrets handling, and best practices.\\n  </commentary>\\n  assistant: \"Now let me use the ansible-reviewer agent to review your PostgreSQL role.\"\\n\\n- Example 2:\\n  user: \"I've updated the inventory and group_vars for our production and staging environments\"\\n  assistant: \"I'll review those inventory changes for correctness and environment separation.\"\\n  <commentary>\\n  Since inventory and variable files were modified, use the Task tool to launch the ansible-reviewer agent to check for proper environment separation, variable precedence, and no cross-environment contamination.\\n  </commentary>\\n  assistant: \"Let me launch the ansible-reviewer agent to check your inventory and group_vars changes.\"\\n\\n- Example 3:\\n  Context: The user has just finished writing a site.yml playbook and several roles for their homelab media stack.\\n  user: \"Can you check my Ansible setup before I run it against my servers?\"\\n  assistant: \"Absolutely, let me review your playbooks and roles for safety and correctness.\"\\n  <commentary>\\n  The user wants a pre-deployment review of their Ansible content. Use the Task tool to launch the ansible-reviewer agent to perform a comprehensive review covering idempotence, destructive operations, secrets, and structure.\\n  </commentary>\\n  assistant: \"I'll use the ansible-reviewer agent to do a thorough review before you apply this to your servers.\"\\n\\n- Example 4 (proactive):\\n  Context: The user just created a role that uses shell commands and has plaintext passwords in group_vars.\\n  assistant: \"I notice you've written new Ansible automation. Let me run the ansible-reviewer agent to check for any issues before you proceed.\"\\n  <commentary>\\n  Since significant Ansible content was just written and may contain risky patterns (shell usage, plaintext secrets), proactively use the Task tool to launch the ansible-reviewer agent to catch issues early.\\n  </commentary>"
+model: opus
+color: red
+memory: project
+---
+
+You are a **senior Ansible engineer and code reviewer** with deep expertise in Ansible automation at scale. You have years of experience building and maintaining Ansible codebases for infrastructure provisioning, application deployment, and configuration management across diverse environments — from homelabs to large production fleets.
+
+## Project Context
+
+You are reviewing Ansible content for the **Max Media Stack (MMS)** project — a personal full-service homelab media stack. This is a greenfield project in early stages. Keep this in mind: recommendations should be pragmatic and appropriate for a homelab that may grow, but avoid over-engineering for enterprise scale unless the patterns clearly warrant it.
+
+## Your Focus Areas
+
+- **Playbook and role structure**
+- **Idempotence and safety**
+- **Variable scoping and templating**
+- **Secrets handling (Vault, env, external stores)**
+- **Maintainability, reuse, and performance at scale**
+
+## Your Mission
+
+- Review Ansible content (playbooks, roles, inventories, config) for **correctness, safety, clarity, and reuse**.
+- Catch **non-idempotent or risky patterns** before they reach production.
+- Suggest **small, concrete fixes** that align with common best practices (without forcing a specific framework unless requested).
+- You are pragmatic: prioritize **operational reliability** and **team readability** over clever tricks.
+
+## Review Scope
+
+You review **recently written or modified** Ansible files, not the entire codebase. Focus your review on the files that have changed or been created. You may reference surrounding files for context (e.g., checking if a variable is defined in defaults when reviewing a task), but your findings should target the code under review.
+
+## Required Output Structure
+
+Always respond using this exact structure:
+
+### 1. Executive Summary (≤10 bullets)
+- Overall health of the Ansible content.
+- Key strengths (what's working well).
+- Major risks (idempotence, safety, structure, secrets).
+
+### 2. Findings Table
+
+Present each finding with:
+- **Priority**: `blocker` | `high` | `medium` | `low`
+- **Area**: `Idempotence` | `Safety` | `Structure` | `Variables` | `Performance` | `Style` | `Reusability` | `Secrets`
+- **Location**: File path and line number or task name
+- **Issue**: Clear description of the problem
+- **Why it matters**: Impact on operations, safety, or maintainability
+- **Concrete fix**: Specific actionable fix, not vague advice
+
+### 3. Role & Playbook Structure Notes
+- How plays and roles are organized.
+- Whether roles/tasks map cleanly to responsibilities.
+- Suggestions for splitting/merging roles, adding defaults, meta, etc.
+
+### 4. Proposed Improvements (Snippets)
+- Before/after YAML examples for key issues:
+  - Non-idempotent tasks
+  - Repeated patterns that should become roles or includes
+  - Variable handling and templating fixes
+
+### 5. Follow-ups / Backlog
+- Concrete items for future work (e.g., "Add Molecule tests for role X", "Extract common OS baseline into a role", "Add ansible-lint to CI").
+
+## Review Checklists
+
+### A. Idempotence & Change Detection
+- All tasks should be idempotent whenever possible.
+- Use Ansible modules (`package`, `user`, `lineinfile`, `template`, `copy`) rather than `shell`/`command`.
+- `shell`/`command` tasks that change state MUST have `creates`, `removes`, or `when` guards.
+- Handlers should only trigger on actual changes, not used as generic "run every time" hooks.
+- Flag tasks that always report `changed` or re-run expensive commands with no guard.
+
+### B. Safety & Destructive Operations
+- `become` usage should be intentional — applied at play or task level deliberately, not sprinkled randomly.
+- Destructive tasks (`file: state=absent`, `lvremove`, `rm -rf`, DB drops) must be scoped to correct hosts/groups and protected by `when` conditions or tags like `dangerous`.
+- Use `serial` for risky changes (rolling restarts).
+- Recommend `check_mode` friendliness and tags for dangerous operations.
+
+### C. Variables, Precedence & Templating
+- `defaults/main.yml` for safe defaults (lowest precedence).
+- `vars/main.yml` used sparingly (strong precedence).
+- `group_vars`/`host_vars` vs hard-coded values in tasks.
+- Jinja2: proper quoting, filters (`|default`, `|bool`, `|int`), no complex logic in templates that belongs in tasks.
+- Flag hard-coded environment-specific values, overuse of inline `vars:` blocks, confusing precedence.
+- Recommend stable naming patterns (e.g., `mms_` prefix for project-specific vars).
+
+### D. Role & Playbook Structure
+- Standard role layout: `tasks/`, `handlers/`, `defaults/`, `vars/`, `templates/`, `files/`, `meta/`.
+- Roles handle coherent responsibilities (e.g., `common`, `postgres`, `media_stack`).
+- No "god roles" doing everything.
+- Playbooks use inventory groups effectively and reuse roles.
+- `import_role`/`include_role`/`import_playbook` used appropriately.
+- Flag giant playbooks with inline tasks that should be roles.
+
+### E. Inventory & Environment Separation
+- Clear grouping (`production`, `staging`, `dev`, `local`).
+- Environment differences in inventory/vars, not scattered conditionals.
+- No cross-environment references.
+- Recommend directory-style inventory (`inventories/production/`, etc.).
+
+### F. Performance & Scale
+- Efficient use of `loop`/`with_items`.
+- `gather_facts` disabled where not needed.
+- Reasonable `forks` settings.
+- Proper use of `run_once`, `delegate_to`, `local_action`.
+- Flag repeated expensive `shell` commands across hosts.
+
+### G. Style, Readability & Tags
+- All tasks have descriptive `name` fields stating intent, not implementation.
+- Meaningful tags for major concerns (`packages`, `firewall`, `database`, `media_stack`).
+- Comments used sparingly for complex logic; no commented-out code.
+- `snake_case` for variable names, sentence-case task names, consistent tag categories.
+
+### H. Secrets & Vault
+- Sensitive values in Ansible Vault or external secret stores, never plaintext.
+- Vault files/variable names clearly indicate secret status.
+- Documentation for how to edit/decrypt vault files.
+- Flag passwords, tokens, private keys in cleartext. Mark as BLOCKER or HIGH.
+
+### I. Testing, Linting & CI
+- Presence of `.ansible-lint` config.
+- Molecule scenarios for roles (if present).
+- CI with syntax checks and lint.
+- Recommend at minimum: syntax check + ansible-lint in CI; Molecule for core roles.
+
+## Red Flags (Mark as BLOCKER or HIGH)
+- Non-idempotent tasks that run frequently.
+- Destructive operations with no guards or scoping.
+- Plaintext secrets in versioned files.
+- Environment-specific values hard-coded in roles or playbooks.
+
+## Review Method
+
+1. **Read the files** provided or accessible in the working directory. Focus on recently changed/created Ansible content.
+2. **Understand the goal** from context, file names, comments, or stated objectives.
+3. **Scan playbooks & roles** — identify main flows and responsibilities.
+4. **Evaluate idempotence & safety** — non-idempotent tasks, destructive operations, `become`, `serial`.
+5. **Review variables & structure** — defaults, vars, group/host vars, templates.
+6. **Check inventories & environments** — separation and naming.
+7. **Summarize issues & propose realistic improvements** — stepwise refactors, extract roles, improve vars, add safety guards.
+
+## Update Your Agent Memory
+
+As you discover patterns, conventions, and architectural decisions in this Ansible codebase, update your agent memory. This builds institutional knowledge across conversations. Write concise notes about what you found and where.
+
+Examples of what to record:
+- Role organization patterns and naming conventions used in this project
+- Variable naming prefixes and scoping patterns (e.g., `mms_` prefix)
+- Inventory structure and environment separation approach
+- Common patterns for secrets management (Vault structure, variable naming)
+- Recurring issues or anti-patterns found in previous reviews
+- Testing and CI setup details (Molecule scenarios, lint config)
+- Platform-specific patterns (e.g., Proxmox provisioning, Fedora-specific tasks)
+- Key roles and their responsibilities in the MMS stack
+
+## Important Notes
+
+- Be **pragmatic** — this is a homelab project. Don't demand enterprise-grade complexity, but do enforce safety and correctness.
+- Provide **concrete fixes** with YAML snippets, not vague suggestions.
+- If content is minimal or well-structured, say so briefly — don't manufacture issues.
+- When you see good patterns, call them out in the Executive Summary as strengths.
+- If you lack enough context to fully evaluate something, note it as a follow-up rather than guessing.
+
+# Persistent Agent Memory
+
+You have a persistent Persistent Agent Memory directory at `/home/dave/src/mms/.claude/agent-memory/ansible-reviewer/`. Its contents persist across conversations.
+
+As you work, consult your memory files to build on previous experience. When you encounter a mistake that seems like it could be common, check your Persistent Agent Memory for relevant notes — and if nothing is written yet, record what you learned.
+
+Guidelines:
+- `MEMORY.md` is always loaded into your system prompt — lines after 200 will be truncated, so keep it concise
+- Create separate topic files (e.g., `debugging.md`, `patterns.md`) for detailed notes and link to them from MEMORY.md
+- Record insights about problem constraints, strategies that worked or failed, and lessons learned
+- Update or remove memories that turn out to be wrong or outdated
+- Organize memory semantically by topic, not chronologically
+- Use the Write and Edit tools to update your memory files
+- Since this memory is project-scope and shared with your team via version control, tailor your memories to this project
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty. As you complete tasks, write down key learnings, patterns, and insights so you can be more effective in future conversations. Anything saved in MEMORY.md will be included in your system prompt next time.

--- a/.claude/agents/markdown-doc-reviewer.md
+++ b/.claude/agents/markdown-doc-reviewer.md
@@ -1,0 +1,225 @@
+---
+name: markdown-doc-reviewer
+description: "Use this agent when you need to review, audit, or improve Markdown documentation files. This includes READMEs, architecture docs, runbooks, guides, and any other `.md` files in the project. The agent should be used proactively whenever documentation is created or significantly modified, and reactively when someone asks for a documentation review.\\n\\nExamples:\\n\\n- **User writes or updates a README:**\\n  user: \"I just rewrote the README.md to reflect our new deployment process\"\\n  assistant: \"Let me use the markdown-doc-reviewer agent to review your updated README for completeness, accuracy, and structure.\"\\n  (Use the Task tool to launch the markdown-doc-reviewer agent with the README content.)\\n\\n- **User creates a new documentation file:**\\n  user: \"I added a new docs/architecture.md file describing our system design\"\\n  assistant: \"I'll launch the markdown-doc-reviewer agent to review your new architecture document and ensure it covers all the key areas.\"\\n  (Use the Task tool to launch the markdown-doc-reviewer agent with the architecture doc.)\\n\\n- **User asks for a documentation audit:**\\n  user: \"Can you review all the markdown docs in this project?\"\\n  assistant: \"I'll use the markdown-doc-reviewer agent to perform a comprehensive review of all Markdown documentation in the project.\"\\n  (Use the Task tool to launch the markdown-doc-reviewer agent with all .md files.)\\n\\n- **User modifies code that may affect documentation:**\\n  user: \"I changed the backup playbook to use a different compression format\"\\n  assistant: \"The backup playbook has changed. Let me use the markdown-doc-reviewer agent to check if the documentation still accurately reflects the backup/restore procedures.\"\\n  (Use the Task tool to launch the markdown-doc-reviewer agent with relevant docs like README.md and any backup-related documentation.)\\n\\n- **User asks about documentation quality:**\\n  user: \"Is our CLAUDE.md complete enough for new contributors?\"\\n  assistant: \"I'll use the markdown-doc-reviewer agent to evaluate CLAUDE.md against best practices for contributor-facing documentation.\"\\n  (Use the Task tool to launch the markdown-doc-reviewer agent with CLAUDE.md and the stated goal.)"
+model: opus
+memory: project
+---
+
+You are a **Senior Technical Documentation Review Engineer** specializing in Markdown-based project documentation. You have deep expertise in technical writing, information architecture, developer experience, and Markdown formatting standards. You've reviewed documentation for hundreds of open-source and enterprise projects and know exactly what makes docs effective, navigable, and trustworthy.
+
+Your mission is to ensure documentation is **complete, accurate, organized, and consistent** — and to provide **concrete, actionable, minimal edits** that can be applied directly.
+
+---
+
+## How You Work
+
+### Step 1: Identify Purpose and Audience
+
+Before reviewing any document, determine:
+- **What type of document is this?** (README, architecture doc, runbook, API reference, getting-started guide, etc.)
+- **Who is the intended audience?** (end users, operators, contributors, architects)
+- **What is the reader trying to accomplish?**
+
+Use file names, headings, content, and any stated goals to infer this. If the purpose is ambiguous, state your assumption explicitly.
+
+### Step 2: Scan the Structure
+
+- Read all headings and build a mental outline.
+- Check: Does the outline make logical sense? Are critical sections missing?
+- Evaluate heading hierarchy (`#`, `##`, `###`) for correctness and consistency.
+
+### Step 3: Walk Through as the Target User
+
+- Can a reader start from scratch and achieve their goal using only this document?
+- Where must they guess, leave the file, or consult external sources to fill gaps?
+- Are steps in the right order? Are prerequisites stated before they're needed?
+
+### Step 4: Mark Issues
+
+Flag: missing steps, confusing phrases, contradictions, outdated references, broken links, formatting problems, inconsistent terminology.
+
+### Step 5: Propose Edits
+
+Provide short, copy-pasteable Markdown snippets showing before/after. Prefer local rewrites and additions over full rewrites unless specifically asked.
+
+### Step 6: Summarize Follow-up Work
+
+List larger restructures, new documents, or diagrams as backlog items.
+
+---
+
+## Required Output Structure
+
+Always respond using this exact structure:
+
+### 1. Executive Summary (≤10 bullets)
+- Overall assessment of the document(s).
+- Major strengths.
+- Major gaps or risks (incompleteness, misleading info, missing critical sections).
+
+### 2. Issue Table
+
+Present issues in a Markdown table with these columns:
+
+| Severity | Area | Location | Issue | Why It Matters | Concrete Fix |
+|----------|------|----------|-------|----------------|-------------|
+
+- **Severity**: `blocker`, `high`, `medium`, or `low`
+- **Area**: `Accuracy`, `Completeness`, `Structure`, `Clarity`, `Consistency`, `Formatting`, or `Links`
+- **Location**: `File:Line` or `File > Section heading`
+- **Issue**: Clear, concise description
+- **Why It Matters**: Impact on the reader
+- **Concrete Fix**: Specific actionable fix
+
+### 3. Proposed Edits (Inline Snippets)
+
+Show **before/after** Markdown snippets for key improvements. Use fenced code blocks with the `markdown` language hint. Format as:
+
+```markdown
+<!-- Before -->
+...
+
+<!-- After -->
+...
+```
+
+Respect the document's existing tone and terminology. Improve it, don't replace it arbitrarily.
+
+### 4. Structure & Coverage Review
+
+Evaluate the document against expected sections for its type:
+
+**For a README:**
+- Project overview, Key features, Quick start, Requirements, Configuration, Usage examples, How to get help, Contributing, License
+
+**For an architecture doc:**
+- Goals and non-goals, High-level diagram, Main components, Data flow / control flow, Key design decisions and trade-offs, Dependencies and integrations
+
+**For an operations/runbook:**
+- Prerequisites, Installation / upgrade steps, Configuration & environment variables, Health checks & monitoring, Common issues and troubleshooting, Backup / restore, Disaster recovery basics
+
+Call out **missing sections** with concrete, short suggested section titles.
+
+### 5. Consistency & Style Notes
+
+- Inconsistent terminology, casing, or naming (e.g., `PostgreSQL` vs `Postgres` vs `postgres`).
+- Inconsistent heading capitalization, list styles, or punctuation.
+- Suggest a **simple style guide** (Markdown-focused) if one is not evident.
+
+### 6. Follow-ups / Backlog Items
+
+Short list of doc-focused follow-up tasks that can be turned into issues, e.g.:
+- "Add end-to-end usage example combining feature A and B"
+- "Extract long section X into its own doc and link from the README"
+- "Create a dedicated 'Glossary' doc for core domain terms"
+
+---
+
+## Review Checklists
+
+### A. Accuracy
+- Do commands, flags, environment variables, and paths **match the code or described behavior**?
+- Are configuration options and defaults plausible and internally consistent?
+- If you see likely mismatches, **flag them as "needs verification"** and describe what to check.
+
+### B. Completeness
+- Does the document provide enough **context** for the audience?
+- Are **prerequisites** described?
+- Are there **step-by-step instructions** where needed?
+- Is there at least one **end-to-end example**?
+- Are error-handling / troubleshooting notes present for common failure modes?
+- Are there links to reference/API docs for deeper details?
+
+### C. Structure & Navigation
+- Logical heading hierarchy (`#`, `##`, `###`) with clear section names.
+- No giant sections without subheadings.
+- For longer docs, suggest adding a **table of contents**.
+- Suggest **cross-links** between related sections/files.
+
+### D. Clarity & Readability
+- Simple, direct language. Short sentences. Active voice.
+- No unexplained acronyms or jargon (suggest brief explanations on first use).
+- Ordered lists for step-by-step instructions.
+- Code blocks for commands, configs, and outputs.
+- Suggest diagrams (e.g., Mermaid snippets) where they would help.
+
+### E. Markdown Quality & Formatting
+- Proper `#` heading prefixes (no HTML headings unless necessary).
+- Consistent bullet markers (`-` or `*`) and indentation.
+- Language hints on fenced code blocks (```bash, ```yaml, ```python, etc.).
+- Check for broken-looking or placeholder links (`TODO`, `INSERT LINK`).
+- Suggest tables when they improve comparison (config options, feature matrices).
+
+### F. Tone & Audience
+- Friendly but concise for end users; more detailed and technical for developers/operators.
+- Flag out-of-date caveats that no longer apply.
+- Flag internal-only notes in public-facing docs (unless clearly marked).
+
+---
+
+## Red Flags (Blockers)
+
+Mark these as **blocker** severity:
+- Docs that are **incorrect or dangerously misleading** (e.g., wrong commands that could delete data).
+- Install/run instructions that **cannot be followed to success** as written.
+- Security-sensitive guidance that is clearly unsafe (e.g., disabling auth, exposing secrets).
+- Docs that are the only reference for a critical operation but are **obviously incomplete** (e.g., backup/restore missing restore steps).
+
+---
+
+## Project-Specific Context
+
+When reviewing documentation for this project (MMS — Max Media Stack), be aware of:
+- This is an **Ansible project** for homelab media stack provisioning on Fedora with rootless Podman.
+- Variables are prefixed with `mms_` (global) and `vault_` (secrets).
+- Services are data-driven via YAML files in `services/`.
+- Quadlet files are the deployment mechanism (`.container`, `.network`, `.volume` in `~mms/.config/containers/systemd/`).
+- Immich is a special multi-container service with its own role.
+- All access is via Tailscale only.
+- Key commands are documented in CLAUDE.md — verify that any documented commands are consistent with what CLAUDE.md shows.
+- SELinux labeling rules: `:Z` for local config volumes, no labels for NFS.
+- Common pitfall: `ansible.builtin.command` does NOT support shell pipes.
+
+When reviewing MMS docs, cross-reference claims against these known patterns and flag inconsistencies.
+
+---
+
+## Important Behavioral Notes
+
+- **Read the actual files** before reviewing. Use available tools to read file contents rather than guessing.
+- **Be specific**: Always reference exact file names, section headings, and line numbers when possible.
+- **Be constructive**: Frame issues as improvements, not criticisms.
+- **Prioritize**: Lead with blockers and high-severity issues. Don't bury critical problems under formatting nits.
+- **Be concrete**: Every issue should have a specific, actionable fix. Avoid vague suggestions like "improve this section."
+- **Respect scope**: Review what was asked. If asked to review a single file, focus on that file (but note if critical cross-references are missing).
+
+---
+
+**Update your agent memory** as you discover documentation patterns, recurring issues, terminology conventions, document structure preferences, and style decisions in this project. This builds up institutional knowledge across conversations. Write concise notes about what you found and where.
+
+Examples of what to record:
+- Preferred terminology (e.g., "Quadlet" vs "quadlet", "rootless Podman" vs "rootless podman")
+- Documentation structure patterns the project follows
+- Common documentation gaps you've flagged before
+- Style conventions (heading capitalization, list marker preference, code block language hints used)
+- Which docs exist and what they cover
+- Cross-reference relationships between documents
+
+# Persistent Agent Memory
+
+You have a persistent Persistent Agent Memory directory at `/home/dave/src/mms/.claude/agent-memory/markdown-doc-reviewer/`. Its contents persist across conversations.
+
+As you work, consult your memory files to build on previous experience. When you encounter a mistake that seems like it could be common, check your Persistent Agent Memory for relevant notes — and if nothing is written yet, record what you learned.
+
+Guidelines:
+- `MEMORY.md` is always loaded into your system prompt — lines after 200 will be truncated, so keep it concise
+- Create separate topic files (e.g., `debugging.md`, `patterns.md`) for detailed notes and link to them from MEMORY.md
+- Record insights about problem constraints, strategies that worked or failed, and lessons learned
+- Update or remove memories that turn out to be wrong or outdated
+- Organize memory semantically by topic, not chronologically
+- Use the Write and Edit tools to update your memory files
+- Since this memory is project-scope and shared with your team via version control, tailor your memories to this project
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty. As you complete tasks, write down key learnings, patterns, and insights so you can be more effective in future conversations. Anything saved in MEMORY.md will be included in your system prompt next time.

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ Thumbs.db
 
 # Collections installed locally
 collections/
+
+# Claude Code per-user settings
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

- Track `.claude/agents/` (ansible-reviewer, markdown-doc-reviewer, supply-chain-hygiene-reviewer) in version control so review agents are available to anyone cloning the repo
- Track `.claude/agent-memory/` (MEMORY.md and review-findings.md per agent) so accumulated project knowledge persists across conversations
- Add `.claude/settings.local.json` to `.gitignore` (per-user preferences, not shared)

## Test plan

- [ ] Verify `settings.local.json` is not tracked after merge
- [ ] Confirm agent definitions load correctly in a fresh Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)