### PR TITLE
Fix LSIO rootless container ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+This repository is an Ansible project for deploying the Max Media Stack on a
+Fedora VM with rootless Podman and Quadlet. Top-level playbooks live in
+`playbooks/`, reusable roles live in `roles/`, and service definitions live in
+`services/*.yml`. Inventory and host variables are under `inventory/`, including
+vault files and `vault.yml.example` templates. Shared Jinja templates are in
+`templates/`; role-specific templates stay inside each role. Wiki source content
+is kept in `docs/wiki/`.
+
+## Build, Test, and Development Commands
+
+- `make setup` creates `.venv`, installs Python tooling, and installs Ansible
+  Galaxy collections from `requirements.yml`.
+- `make hooks` installs the configured pre-commit hooks.
+- `make lint` runs `yamllint` and `ansible-lint` against playbooks and roles.
+- `make check` runs `playbooks/site.yml` in Ansible check mode with diffs.
+- `make deploy` applies the full stack with `playbooks/site.yml`.
+
+Use `ansible-playbook playbooks/deploy-service.yml -e service_name=radarr` for
+focused service deployment when appropriate.
+
+## Coding Style & Naming Conventions
+
+Use two-space YAML indentation and keep tasks explicit and readable. Role names
+use snake_case, for example `roles/base_system` and `roles/quadlet_service`.
+Service files use lowercase names matching the service key, such as
+`services/sonarr.yml`. Keep role defaults in `defaults/main.yml`, handlers in
+`handlers/main.yml`, and templates beside the role that owns them. Run
+`make lint` before opening a pull request; the repo also uses pre-commit hooks
+for YAML checks, secret detection, trailing whitespace, and large-file checks.
+
+## Testing Guidelines
+
+Molecule scenarios live under `roles/<role>/molecule/default/`. Add or update a
+scenario when changing role behavior, especially generated Quadlet files,
+firewall/system settings, or service configuration. Run focused tests with
+`source .venv/bin/activate && molecule test -s default` from the role directory.
+For broader validation, run `make check` to verify the site playbook can render
+and plan changes without applying them.
+
+## Commit & Pull Request Guidelines
+
+Recent history uses Conventional Commit style, especially Renovate commits like
+`chore(deps): update dependency community.general to v12.6.0`. Use an
+imperative, scoped subject when possible, such as `fix(traefik): correct dynamic
+router template`. Pull requests should describe the deployed behavior, list the
+validation commands run, and call out any inventory, vault, DNS, or host changes
+operators must make.
+
+## Security & Configuration Tips
+
+Do not commit secrets. Keep real credentials in Ansible Vault files and update
+the matching `vault.yml.example` only with placeholder values. Treat changes to
+firewall rules, published ports, Podman socket access, and SELinux labels as
+security-sensitive; document the operational impact in the pull request.

--- a/docs/wiki/Kometa.md
+++ b/docs/wiki/Kometa.md
@@ -23,7 +23,7 @@ systemctl --user restart kometa.service
 systemctl --user status kometa.service
 ```
 
-Kometa runs as a long-lived container that wakes at the configured time (`KOMETA_TIME=06:00`) to process metadata, then sleeps until the next run.
+Kometa runs as a long-lived container that wakes at the configured time (`KOMETA_TIMES=06:00`) to process metadata, then sleeps until the next run.
 
 ## Viewing Logs
 
@@ -46,6 +46,7 @@ systemctl --user stop kometa.service
 # Run interactively with immediate execution
 podman run --rm -it \
   --name test-kometa \
+  --userns=host \
   --network mms \
   --tmpfs /run:U \
   -e PUID=3000 \
@@ -60,6 +61,7 @@ podman run --rm -it \
 
 **LSIO image rules (these are critical for Kometa testing):**
 - Use `PUID`/`PGID` environment variables -- do **NOT** use `--userns=keep-id` (breaks s6-overlay preinit, causing `s6-overlay-suexec: fatal: unable to exec /etc/s6-overlay/s6-rc.d/init/run: Operation not permitted`)
+- Use `--userns=host` so rootless Podman maps the host `mms` user to root inside the container for s6-overlay startup
 - Use `--network mms` (the Podman network name), not `--network mms.network` (that's the Quadlet filename, not the network)
 - Use `--tmpfs /run:U` for s6-overlay compatibility (`:U` chowns to container user)
 - Use `:Z` on the config volume for SELinux private labeling
@@ -102,7 +104,7 @@ This is the most common gotcha when manually testing Kometa. LSIO images use s6-
 s6-overlay-suexec: fatal: unable to exec /etc/s6-overlay/s6-rc.d/init/run: Operation not permitted
 ```
 
-**Solution:** Remove `--userns=keep-id` and use `PUID`/`PGID` instead. The Quadlet template uses `UserNS=keep-id` by default, but the LSIO container's s6-overlay handles the user switch internally via PUID/PGID.
+**Solution:** Use `UserNS=host` with `PUID`/`PGID`. Rootless Podman still maps the host `mms` user to root inside the container, and the LSIO container's s6-overlay handles the app user switch internally via PUID/PGID.
 
 **"Network mms.network not found"**
 

--- a/docs/wiki/Kometa.md
+++ b/docs/wiki/Kometa.md
@@ -49,8 +49,8 @@ podman run --rm -it \
   --userns=host \
   --network mms \
   --tmpfs /run:U \
-  -e PUID=3000 \
-  -e PGID=3000 \
+  -e PUID=0 \
+  -e PGID=0 \
   -e TZ=America/New_York \
   -e KOMETA_RUN=true \
   -v /home/mms/config/kometa:/config:Z \
@@ -62,16 +62,17 @@ podman run --rm -it \
 **LSIO image rules (these are critical for Kometa testing):**
 - Use `PUID`/`PGID` environment variables -- do **NOT** use `--userns=keep-id` (breaks s6-overlay preinit, causing `s6-overlay-suexec: fatal: unable to exec /etc/s6-overlay/s6-rc.d/init/run: Operation not permitted`)
 - Use `--userns=host` so rootless Podman maps the host `mms` user to root inside the container for s6-overlay startup
+- Use `PUID=0`/`PGID=0` so files written by Kometa remain editable by the host `mms` user
 - Use `--network mms` (the Podman network name), not `--network mms.network` (that's the Quadlet filename, not the network)
 - Use `--tmpfs /run:U` for s6-overlay compatibility (`:U` chowns to container user)
 - Use `:Z` on the config volume for SELinux private labeling
 
 **Fix file ownership after manual runs:**
 
-If you ran a test container with different user mappings (or accidentally with `--userns=keep-id`), config files may end up owned by the wrong user inside the namespace. Fix with:
+If you ran a test container with different user mappings (or accidentally with `PUID=3000`), config files may end up owned by a rootless Podman subuid such as `592823`. Fix with:
 
 ```bash
-podman unshare chown -R 3000:3000 /home/mms/config/kometa
+podman unshare chown -R 0:0 /home/mms/config/kometa
 ```
 
 ## Backup & Restore
@@ -104,7 +105,7 @@ This is the most common gotcha when manually testing Kometa. LSIO images use s6-
 s6-overlay-suexec: fatal: unable to exec /etc/s6-overlay/s6-rc.d/init/run: Operation not permitted
 ```
 
-**Solution:** Use `UserNS=host` with `PUID`/`PGID`. Rootless Podman still maps the host `mms` user to root inside the container, and the LSIO container's s6-overlay handles the app user switch internally via PUID/PGID.
+**Solution:** Use `UserNS=host` with `PUID=0` and `PGID=0`. Rootless Podman still maps container root to the host `mms` user, so s6-overlay can start and Kometa-written files stay editable from the host.
 
 **"Network mms.network not found"**
 
@@ -123,7 +124,7 @@ podman run --network mms ...
 After a manual run, files in `/home/mms/config/kometa` may be owned by a different UID inside the user namespace. Fix ownership:
 
 ```bash
-podman unshare chown -R 3000:3000 /home/mms/config/kometa
+podman unshare chown -R 0:0 /home/mms/config/kometa
 ```
 
 **Kometa can't connect to Plex**

--- a/docs/wiki/Kometa.md
+++ b/docs/wiki/Kometa.md
@@ -129,10 +129,25 @@ podman unshare chown -R 0:0 /home/mms/config/kometa
 
 **Kometa can't connect to Plex**
 
-Verify Plex is running and reachable from within the network:
+First verify Plex is running and reachable from within the container network:
 
 ```bash
 podman exec kometa curl -sf http://plex:32400/identity
 ```
 
-Also verify the Plex URL in Kometa's config YAML uses the container hostname (`http://plex:32400`), not a Traefik URL.
+This checks connectivity only. Plex may return `200 OK` from `/identity` even with
+an invalid token, so do not use this endpoint to validate credentials.
+
+Validate the Plex token against an authenticated API endpoint:
+
+```bash
+podman exec kometa curl -i \
+  "http://plex:32400/library/sections?X-Plex-Token=<plex-token>"
+```
+
+A valid token returns `200 OK` with a `MediaContainer` listing libraries. An
+invalid token returns `401 Unauthorized`.
+
+Also verify the Plex URL in Kometa's config YAML uses the container hostname
+(`http://plex:32400`), not a Traefik URL. Check both the global `plex:` block
+and any per-library `plex:` overrides.

--- a/docs/wiki/Lidarr.md
+++ b/docs/wiki/Lidarr.md
@@ -46,8 +46,8 @@ podman run --rm -it \
   --name test-lidarr \
   --network mms \
   --tmpfs /run:U \
-  -e PUID=3000 \
-  -e PGID=3000 \
+  -e PUID=0 \
+  -e PGID=0 \
   -e TZ=America/New_York \
   -v /home/mms/config/lidarr:/config:Z \
   -v /data:/data \

--- a/docs/wiki/Prowlarr.md
+++ b/docs/wiki/Prowlarr.md
@@ -56,8 +56,8 @@ podman run --rm -it \
   --name test-prowlarr \
   --network mms \
   --tmpfs /run:U \
-  -e PUID=3000 \
-  -e PGID=3000 \
+  -e PUID=0 \
+  -e PGID=0 \
   -e TZ=America/New_York \
   -v /home/mms/config/prowlarr:/config:Z \
   lscr.io/linuxserver/prowlarr:latest

--- a/docs/wiki/Radarr-4K.md
+++ b/docs/wiki/Radarr-4K.md
@@ -40,8 +40,8 @@ podman run --rm -it \
   --name test-radarr4k \
   --network mms \
   --tmpfs /run:U \
-  -e PUID=3000 \
-  -e PGID=3000 \
+  -e PUID=0 \
+  -e PGID=0 \
   -e TZ=America/New_York \
   -v /home/mms/config/radarr4k:/config:Z \
   -v /data:/data \

--- a/docs/wiki/Radarr.md
+++ b/docs/wiki/Radarr.md
@@ -57,8 +57,8 @@ podman run --rm -it \
   --name test-radarr \
   --network mms \
   --tmpfs /run:U \
-  -e PUID=3000 \
-  -e PGID=3000 \
+  -e PUID=0 \
+  -e PGID=0 \
   -e TZ=America/New_York \
   -v /home/mms/config/radarr:/config:Z \
   -v /data:/data \

--- a/docs/wiki/SABnzbd.md
+++ b/docs/wiki/SABnzbd.md
@@ -46,8 +46,8 @@ podman run --rm -it \
   --name test-sabnzbd \
   --network mms \
   --tmpfs /run:U \
-  -e PUID=3000 \
-  -e PGID=3000 \
+  -e PUID=0 \
+  -e PGID=0 \
   -e TZ=America/New_York \
   -v /home/mms/config/sabnzbd:/config:Z \
   -v /data:/data \

--- a/docs/wiki/Sonarr.md
+++ b/docs/wiki/Sonarr.md
@@ -46,8 +46,8 @@ podman run --rm -it \
   --name test-sonarr \
   --network mms \
   --tmpfs /run:U \
-  -e PUID=3000 \
-  -e PGID=3000 \
+  -e PUID=0 \
+  -e PGID=0 \
   -e TZ=America/New_York \
   -v /home/mms/config/sonarr:/config:Z \
   -v /data:/data \

--- a/docs/wiki/Tautulli.md
+++ b/docs/wiki/Tautulli.md
@@ -46,8 +46,8 @@ podman run --rm -it \
   --name test-tautulli \
   --network mms \
   --tmpfs /run:U \
-  -e PUID=3000 \
-  -e PGID=3000 \
+  -e PUID=0 \
+  -e PGID=0 \
   -e TZ=America/New_York \
   -v /home/mms/config/tautulli:/config:Z \
   -v "/home/mms/config/plex/Library/Application Support/Plex Media Server/Logs:/plex-logs:ro" \

--- a/roles/quadlet_service/molecule/default/verify.yml
+++ b/roles/quadlet_service/molecule/default/verify.yml
@@ -26,12 +26,12 @@
         src: /home/mms/.config/containers/systemd/testapp.container
       register: _quadlet_service_quadlet_content
 
-    - name: Verify PUID/PGID services run as root inside the container
+    - name: Verify PUID/PGID services map writes to the host user
       ansible.builtin.assert:
         that:
           - "'UserNS=host' in _quadlet_service_quadlet_decoded"
-          - "'PUID=3000' in _quadlet_service_quadlet_decoded"
-          - "'PGID=3000' in _quadlet_service_quadlet_decoded"
-        fail_msg: "PUID/PGID services must not default to UserNS=keep-id"
+          - "'PUID=0' in _quadlet_service_quadlet_decoded"
+          - "'PGID=0' in _quadlet_service_quadlet_decoded"
+        fail_msg: "Rootless PUID/PGID services must write files as the host user"
       vars:
         _quadlet_service_quadlet_decoded: "{{ _quadlet_service_quadlet_content.content | b64decode }}"

--- a/roles/quadlet_service/molecule/default/verify.yml
+++ b/roles/quadlet_service/molecule/default/verify.yml
@@ -20,3 +20,18 @@
         path: /home/mms/.config/containers/systemd/testapp.container
       register: _quadlet_service_quadlet_file
       failed_when: not _quadlet_service_quadlet_file.stat.exists
+
+    - name: Read container quadlet file
+      ansible.builtin.slurp:
+        src: /home/mms/.config/containers/systemd/testapp.container
+      register: _quadlet_service_quadlet_content
+
+    - name: Verify PUID/PGID services run as root inside the container
+      ansible.builtin.assert:
+        that:
+          - "'UserNS=host' in _quadlet_service_quadlet_decoded"
+          - "'PUID=3000' in _quadlet_service_quadlet_decoded"
+          - "'PGID=3000' in _quadlet_service_quadlet_decoded"
+        fail_msg: "PUID/PGID services must not default to UserNS=keep-id"
+      vars:
+        _quadlet_service_quadlet_decoded: "{{ _quadlet_service_quadlet_content.content | b64decode }}"

--- a/roles/quadlet_service/molecule/services/testapp.yml
+++ b/roles/quadlet_service/molecule/services/testapp.yml
@@ -8,6 +8,6 @@ testapp:
   volumes:
     - "/opt/mms/config/testapp:/config:Z"
   environment:
-    - "PUID=3000"
-    - "PGID=3000"
+    - "PUID=0"
+    - "PGID=0"
     - "TZ=America/New_York"

--- a/services/channels.yml
+++ b/services/channels.yml
@@ -3,6 +3,7 @@ channels:
   name: channels
   description: "Channels DVR - Live TV and DVR"
   image: "fancybits/channels-dvr:latest@sha256:284fed6f4ee5150d41d9a7f247a63e190f6f1c3a4e4bc740f029df6d36955d29"
+  userns: "keep-id"
   volumes:
     - "{{ mms_config_dir }}/channels:/channels-dvr:Z"
     - "/data/recordings:/shares/DVR"

--- a/services/jellyfin.yml
+++ b/services/jellyfin.yml
@@ -3,6 +3,7 @@ jellyfin:
   name: jellyfin
   description: "Jellyfin - Media Server"
   image: "docker.io/jellyfin/jellyfin:10.11.8"
+  userns: "keep-id"
   tmpfs:
     - "/cache:U"
   volumes:

--- a/services/kometa.yml
+++ b/services/kometa.yml
@@ -11,6 +11,6 @@ kometa:
     - "PUID={{ mms_uid }}"
     - "PGID={{ mms_gid }}"
     - "TZ={{ mms_timezone }}"
-    - "KOMETA_TIME=06:00"
+    - "KOMETA_TIMES=06:00"
   backup_type: "arr"
   backup_db_files: []

--- a/services/kometa.yml
+++ b/services/kometa.yml
@@ -8,8 +8,8 @@ kometa:
   volumes:
     - "{{ mms_config_dir }}/kometa:/config:Z"
   environment:
-    - "PUID={{ mms_uid }}"
-    - "PGID={{ mms_gid }}"
+    - "PUID=0"
+    - "PGID=0"
     - "TZ={{ mms_timezone }}"
     - "KOMETA_TIMES=06:00"
   backup_type: "arr"

--- a/services/lidarr.yml
+++ b/services/lidarr.yml
@@ -7,8 +7,8 @@ lidarr:
     - "{{ mms_config_dir }}/lidarr:/config:Z"
     - "{{ mms_data_dir }}:/data"
   environment:
-    - "PUID={{ mms_uid }}"
-    - "PGID={{ mms_gid }}"
+    - "PUID=0"
+    - "PGID=0"
     - "TZ={{ mms_timezone }}"
   health_cmd: "curl -sf http://localhost:8686/ping || exit 1"
   health_interval: "60s"

--- a/services/navidrome.yml
+++ b/services/navidrome.yml
@@ -3,6 +3,7 @@ navidrome:
   name: navidrome
   description: "Navidrome - Music Streaming Server"
   image: "deluan/navidrome:0.61.2"
+  userns: "keep-id"
   user: "{{ mms_uid }}:{{ mms_gid }}"
   volumes:
     - "{{ mms_config_dir }}/navidrome:/data:Z"

--- a/services/prowlarr.yml
+++ b/services/prowlarr.yml
@@ -6,8 +6,8 @@ prowlarr:
   volumes:
     - "{{ mms_config_dir }}/prowlarr:/config:Z"
   environment:
-    - "PUID={{ mms_uid }}"
-    - "PGID={{ mms_gid }}"
+    - "PUID=0"
+    - "PGID=0"
     - "TZ={{ mms_timezone }}"
   health_cmd: "curl -sf http://localhost:9696/ping || exit 1"
   health_interval: "60s"

--- a/services/radarr.yml
+++ b/services/radarr.yml
@@ -7,8 +7,8 @@ radarr:
     - "{{ mms_config_dir }}/radarr:/config:Z"
     - "{{ mms_data_dir }}:/data"
   environment:
-    - "PUID={{ mms_uid }}"
-    - "PGID={{ mms_gid }}"
+    - "PUID=0"
+    - "PGID=0"
     - "TZ={{ mms_timezone }}"
   health_cmd: "curl -sf http://localhost:7878/ping || exit 1"
   health_interval: "60s"

--- a/services/radarr4k.yml
+++ b/services/radarr4k.yml
@@ -7,8 +7,8 @@ radarr4k:
     - "{{ mms_config_dir }}/radarr4k:/config:Z"
     - "{{ mms_data_dir }}:/data"
   environment:
-    - "PUID={{ mms_uid }}"
-    - "PGID={{ mms_gid }}"
+    - "PUID=0"
+    - "PGID=0"
     - "TZ={{ mms_timezone }}"
   health_cmd: "curl -sf http://localhost:7878/ping || exit 1"
   health_interval: "60s"

--- a/services/sabnzbd.yml
+++ b/services/sabnzbd.yml
@@ -7,8 +7,8 @@ sabnzbd:
     - "{{ mms_config_dir }}/sabnzbd:/config:Z"
     - "{{ mms_data_dir }}:/data"
   environment:
-    - "PUID={{ mms_uid }}"
-    - "PGID={{ mms_gid }}"
+    - "PUID=0"
+    - "PGID=0"
     - "TZ={{ mms_timezone }}"
   health_cmd: "curl -sf http://localhost:8080/api?mode=version || exit 1"
   health_interval: "60s"

--- a/services/sonarr.yml
+++ b/services/sonarr.yml
@@ -7,8 +7,8 @@ sonarr:
     - "{{ mms_config_dir }}/sonarr:/config:Z"
     - "{{ mms_data_dir }}:/data"
   environment:
-    - "PUID={{ mms_uid }}"
-    - "PGID={{ mms_gid }}"
+    - "PUID=0"
+    - "PGID=0"
     - "TZ={{ mms_timezone }}"
   health_cmd: "curl -sf http://localhost:8989/ping || exit 1"
   health_interval: "60s"

--- a/services/tautulli.yml
+++ b/services/tautulli.yml
@@ -9,8 +9,8 @@ tautulli:
     - "{{ mms_config_dir }}/tautulli:/config:Z"
     - "{{ mms_config_dir }}/plex/Library/Application Support/Plex Media Server/Logs:/plex-logs:ro"
   environment:
-    - "PUID={{ mms_uid }}"
-    - "PGID={{ mms_gid }}"
+    - "PUID=0"
+    - "PGID=0"
     - "TZ={{ mms_timezone }}"
   health_cmd: "curl -sf http://localhost:8181/status || exit 1"
   health_interval: "60s"

--- a/templates/quadlet/container.j2
+++ b/templates/quadlet/container.j2
@@ -12,7 +12,7 @@ After={{ dep }}
 [Container]
 ContainerName={{ quadlet_service_def.name }}
 Image={{ quadlet_service_def.image }}
-UserNS={{ quadlet_service_def.userns | default('keep-id') }}
+UserNS={{ quadlet_service_def.userns | default('host') }}
 {% for group in quadlet_service_def.group_add | default([]) %}
 GroupAdd={{ group }}
 {% endfor %}


### PR DESCRIPTION
## Summary
- default generated Quadlet containers to `UserNS=host` so LSIO s6-overlay images can start under rootless Podman
- set LSIO service `PUID`/`PGID` values to `0` so config files remain owned by the host `mms` user
- add Kometa docs for Plex token testing, Trakt/Kometa run notes, and rootless ownership repair

## Test Plan
- Rendered Kometa Quadlet and confirmed `UserNS=host`
- Rendered Tautulli environment and confirmed `PUID=0` / `PGID=0`
- `yamllint -c .yamllint.yml` on touched YAML files
- `ansible-lint` on touched service definitions and Quadlet verify playbook
- `git diff --check origin/main..HEAD`
