### PR TITLE
feat(logging): add policy-driven log inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Ansible project to provision and manage a full homelab media stack on a Fedora V
 | Channels  | `channels.media.example.com`     | Live TV and DVR                |
 | Navidrome | `navidrome.media.example.com`    | Music streaming server         |
 | Open Notebook | `notebook.media.example.com` | AI research notebook           |
-| Grafana   | `grafana.media.example.com`    | Observability dashboard and alerting |
+| Grafana   | `grafana.media.example.com`    | Observability dashboard, alerting, and log inspection |
 
 ## Architecture
 

--- a/docs/superpowers/plans/2026-05-10-log-inspection-issue-21.md
+++ b/docs/superpowers/plans/2026-05-10-log-inspection-issue-21.md
@@ -1,0 +1,126 @@
+# Log Inspection Issue 21 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add policy-driven periodic inspection of centralized container logs collected by the existing logging role.
+
+**Architecture:** Keep the existing Loki, Alloy, Prometheus, and Grafana stack. Add a standard-library Python inspection CLI that can evaluate JSON policies against either generated JSONL test corpora or live Loki query results, then deploy it with a rootless systemd user service and timer.
+
+**Tech Stack:** Ansible, rootless Podman Quadlet, systemd user units, Python 3 standard library, JSON policy files, pytest functional tests.
+
+---
+
+## File Structure
+
+- Create `scripts/mms-log-inspect`: reusable CLI for local corpus and Loki inspection.
+- Create `scripts/generate-test-corpus`: deterministic log corpus generator for functional tests and local validation.
+- Create `tests/logging/test_log_inspection.py`: behavior tests that exercise generated corpora and policy evaluation through the CLI.
+- Create `examples/log-policies/*.json`: user-facing example policies that demonstrate error, disk, auth, and silence-style inspection.
+- Create `roles/logging/templates/mms-log-inspect.service.j2`: rootless systemd user service that runs the CLI against Loki.
+- Create `roles/logging/templates/mms-log-inspect.timer.j2`: periodic systemd user timer.
+- Modify `roles/logging/defaults/main.yml`: policy, schedule, output, and threshold defaults.
+- Modify `roles/logging/tasks/setup.yml`: deploy the CLI, policy files, output directory, service, and timer.
+- Modify `roles/logging/tasks/containers.yml`: enable and start the timer after Loki is available.
+- Modify `roles/logging/handlers/main.yml`: restart the timer when its unit changes.
+- Modify `docs/wiki/Observability.md`: document policy format, examples, commands, and generated corpus testing.
+
+## Tasks
+
+### Task 1: Add Functional Test Skeleton
+
+**Files:**
+- Create: `tests/logging/test_log_inspection.py`
+- Create: `scripts/generate-test-corpus`
+- Create: `scripts/mms-log-inspect`
+
+- [ ] Write failing pytest coverage that calls `scripts/generate-test-corpus` to create `clean.jsonl` and `faulty.jsonl`, then calls `scripts/mms-log-inspect --input-jsonl ... --policy ... --output-json ...`.
+- [ ] Cover no findings for the clean corpus, findings for disk/auth/error patterns, stable JSON output, and non-zero exit for malformed policy files.
+- [ ] Run `source .venv/bin/activate && pytest -q tests/logging/test_log_inspection.py`; expected result is failure because the scripts do not exist yet.
+- [ ] Commit after the scripts are minimally scaffolded and tests pass:
+
+```bash
+git add scripts/generate-test-corpus scripts/mms-log-inspect tests/logging/test_log_inspection.py
+git commit -m "test(logging): cover policy-driven log inspection"
+```
+
+### Task 2: Implement Local Corpus Inspection
+
+**Files:**
+- Modify: `scripts/generate-test-corpus`
+- Modify: `scripts/mms-log-inspect`
+- Create: `examples/log-policies/error-patterns.json`
+- Create: `examples/log-policies/storage-pressure.json`
+- Create: `examples/log-policies/auth-failures.json`
+
+- [ ] Implement `generate-test-corpus` with `--scenario clean|faulty|adversarial`, `--output`, and `--entries` arguments.
+- [ ] Implement JSONL entries with `timestamp`, `service`, `unit`, and `message` fields.
+- [ ] Implement `mms-log-inspect` local mode with `--input-jsonl`, `--policy`, `--output-json`, and `--fail-on severity`.
+- [ ] Define policy fields: `name`, `description`, `window_minutes`, and `rules`. Each rule has `id`, `severity`, `description`, `service`, `patterns`, and `threshold`.
+- [ ] Treat invalid regexes, missing fields, and malformed JSON as actionable errors with exit code 2.
+- [ ] Run the focused pytest file and fix until clean.
+- [ ] Commit:
+
+```bash
+git add scripts/generate-test-corpus scripts/mms-log-inspect examples/log-policies tests/logging/test_log_inspection.py
+git commit -m "feat(logging): add local policy log inspector"
+```
+
+### Task 3: Add Loki Query Mode and Ansible Deployment
+
+**Files:**
+- Modify: `scripts/mms-log-inspect`
+- Modify: `roles/logging/defaults/main.yml`
+- Modify: `roles/logging/tasks/setup.yml`
+- Modify: `roles/logging/tasks/containers.yml`
+- Modify: `roles/logging/handlers/main.yml`
+- Create: `roles/logging/templates/mms-log-inspect.service.j2`
+- Create: `roles/logging/templates/mms-log-inspect.timer.j2`
+
+- [ ] Add `--loki-url`, `--lookback-minutes`, and `--query-limit` to `mms-log-inspect`.
+- [ ] Query Loki's `/loki/api/v1/query_range` endpoint with a broad `{job="mms"}` selector, parse stream values, and reuse the same policy evaluator.
+- [ ] Add role defaults for `logging_inspection_enabled`, `logging_inspection_schedule`, `logging_inspection_lookback_minutes`, `logging_inspection_query_limit`, `logging_inspection_fail_on`, `logging_inspection_policy_dir`, and `logging_inspection_output_file`.
+- [ ] Deploy the CLI into `{{ logging_config_dir }}/bin/mms-log-inspect`, deploy example policies into `{{ logging_inspection_policy_dir }}`, create `{{ logging_config_dir }}/inspection`, and install service/timer units.
+- [ ] Enable and start `mms-log-inspect.timer` only when `logging_inspection_enabled` is true.
+- [ ] Run `make lint` and fix Ansible/YAML issues.
+- [ ] Commit:
+
+```bash
+git add roles/logging scripts/mms-log-inspect
+git commit -m "feat(logging): schedule periodic Loki log inspection"
+```
+
+### Task 4: Add Documentation and Example Usage
+
+**Files:**
+- Modify: `docs/wiki/Observability.md`
+- Modify: `README.md` if it has an observability feature list.
+
+- [ ] Document what the timer does, where policies live, where results are written, and how to run the inspector manually.
+- [ ] Document policy schema with a concise JSON example.
+- [ ] Document functional testing with `scripts/generate-test-corpus` and `scripts/mms-log-inspect`.
+- [ ] Document operational commands for `systemctl --user status mms-log-inspect.timer` and reading the output JSON.
+- [ ] Commit:
+
+```bash
+git add docs/wiki/Observability.md README.md
+git commit -m "docs(logging): document log inspection policies"
+```
+
+### Task 5: Adversarial Review and PR
+
+**Files:**
+- Modify only files needed to fix concrete review findings.
+
+- [ ] Review the plan adversarially before final implementation: look for target-host dependencies, timer failure behavior, false positive risks, policy bypasses, Ansible idempotence, and missing tests.
+- [ ] Review the resulting diff adversarially after implementation using the same categories.
+- [ ] Run `source .venv/bin/activate && pytest -q tests/logging/test_log_inspection.py`.
+- [ ] Run `make lint`.
+- [ ] Push the branch:
+
+```bash
+git push -u origin feat/issue-21-log-inspection
+```
+
+- [ ] Open a PR that references issue 21 and describes deployed behavior.
+- [ ] If any work is deferred, file a GitHub issue for each deferred item and repeat this workflow for each new issue.
+- [ ] Shepherd review comments through follow-up commits until the PR is merged.

--- a/docs/superpowers/reviews/2026-05-10-log-inspection-issue-21.md
+++ b/docs/superpowers/reviews/2026-05-10-log-inspection-issue-21.md
@@ -1,0 +1,40 @@
+# Issue 21 Log Inspection Adversarial Review
+
+## Plan Review
+
+The original plan correctly separated centralized collection from periodic
+inspection: Loki and Alloy already existed, while the missing work was a policy
+runner, examples, generated corpora, tests, and operator documentation.
+
+Findings reviewed before implementation:
+
+- Target-host dependencies: resolved by using Python standard library only and
+  JSON policies instead of requiring PyYAML or another runtime package.
+- Testability: resolved by adding `scripts/generate-test-corpus` and local
+  JSONL inspection mode so policies can be tested without a live Loki instance.
+- Policy examples: resolved by adding example policies for application errors,
+  storage pressure, and authentication failures.
+- False positives: addressed with an adversarial corpus that includes near-miss
+  log lines and verifies they do not trigger the example test policy.
+- Deployment access: plan required a host-side timer to query Loki. Code review
+  confirmed this needed a loopback-only Loki port binding.
+
+## Code Review
+
+Findings reviewed after implementation:
+
+- Systemd unit path: the first deployment used the Quadlet directory for the
+  inspection `.service` and `.timer`. That would not load as ordinary user
+  systemd units. Fixed in commit `fix(logging): install inspection units in user
+  systemd` by deploying to `{{ mms_home }}/.config/systemd/user`.
+- Loki exposure: the inspector needs host access to Loki. Fixed by publishing
+  `127.0.0.1:3100:3100`, which avoids LAN exposure while enabling local API
+  checks.
+- Policy window mismatch: example policies use a 60-minute window. The deployed
+  timer now queries a 60-minute lookback by default.
+- Malformed policies: covered by functional tests that require actionable
+  errors and exit code 2 for invalid JSON policy content.
+- PR risk: no follow-up work is deferred. If reviewers request notification
+  delivery, silence detection beyond pattern policies, or persistent historical
+  reports, those should be filed as separate issues because they add new
+  behavior beyond issue 21's periodic inspection request.

--- a/docs/wiki/Observability.md
+++ b/docs/wiki/Observability.md
@@ -2,7 +2,11 @@
 
 Centralized logging and metrics stack -- Loki for log storage, Alloy for journal collection and host metrics, Prometheus for metrics storage, podman-exporter for container metrics, and Grafana for dashboards.
 
-All five containers are managed by the `logging` role. Grafana state, Prometheus TSDB, and Loki data are disposable -- Grafana is fully provisioned from Ansible templates, while Prometheus and Loki will repopulate from live data. **None require backup.**
+All five containers are managed by the `logging` role. The role also installs a
+policy-driven log inspection timer that queries Loki on a schedule and writes the
+latest JSON report to disk. Grafana state, Prometheus TSDB, and Loki data are
+disposable -- Grafana is fully provisioned from Ansible templates, while
+Prometheus and Loki will repopulate from live data. **None require backup.**
 
 ## Containers
 
@@ -23,6 +27,9 @@ All five containers are managed by the `logging` role. Grafana state, Prometheus
 | **Prometheus data** | `/home/mms/config/logging/prometheus-data` |
 | **Prometheus retention** | 30 days |
 | **Loki retention** | 30 days (720h) |
+| **Log inspection timer** | Every 15 minutes |
+| **Log inspection policies** | `/home/mms/config/logging/inspection/policies` |
+| **Latest inspection report** | `/home/mms/config/logging/inspection/latest-report.json` |
 | **Autodeploy group** | `interactive` (daily at 02:00) |
 
 ## Service Management
@@ -72,6 +79,15 @@ systemctl --user restart grafana.service
 systemctl --user status grafana.service
 ```
 
+### Log Inspection
+
+```bash
+systemctl --user start mms-log-inspect.service
+systemctl --user status mms-log-inspect.service
+systemctl --user status mms-log-inspect.timer
+systemctl --user list-timers mms-log-inspect.timer
+```
+
 ## Viewing Logs
 
 ```bash
@@ -87,13 +103,99 @@ journalctl --user -u loki --since today
 journalctl --user -u alloy --since today
 journalctl --user -u prometheus --since today
 journalctl --user -u grafana --since today
+
+# Latest policy inspection report
+python3 -m json.tool ~/config/logging/inspection/latest-report.json
 ```
+
+## Log Inspection Policies
+
+The `logging` role installs `mms-log-inspect`, a dependency-free Python CLI that
+queries Loki's local API and evaluates JSON policy files. Loki is published on
+`127.0.0.1:3100` only so the host-side timer can query it without exposing Loki
+on the LAN.
+
+Default example policies are deployed from `examples/log-policies/` to
+`~/config/logging/inspection/policies/`. Add custom `*.json` files to that
+directory and restart the timer if the schedule changed:
+
+```bash
+systemctl --user restart mms-log-inspect.timer
+```
+
+Policy files use this shape:
+
+```json
+{
+  "name": "storage-pressure",
+  "description": "Detect log messages that indicate storage exhaustion.",
+  "window_minutes": 60,
+  "rules": [
+    {
+      "id": "disk-full",
+      "severity": "critical",
+      "description": "A service reports that disk space is exhausted.",
+      "service": "*",
+      "patterns": ["no space left on device", "ENOSPC", "disk full"],
+      "threshold": 1
+    }
+  ]
+}
+```
+
+Supported severities are `info`, `warning`, and `critical`. `service` can be
+`*`, a service name such as `radarr`, or a systemd unit such as
+`radarr.service`. `patterns` are Python regular expressions evaluated
+case-insensitively against each log line. A rule becomes a finding when the
+number of matching log entries is greater than or equal to `threshold`.
+
+Run an inspection manually against Loki:
+
+```bash
+~/config/logging/bin/mms-log-inspect \
+  --loki-url http://localhost:3100 \
+  --lookback-minutes 15 \
+  --query-limit 5000 \
+  --policy ~/config/logging/inspection/policies \
+  --output-json ~/config/logging/inspection/latest-report.json \
+  --fail-on critical
+```
+
+The command exits `1` when findings at or above `--fail-on` exist. The systemd
+service uses that exit code so critical policy matches are visible through
+`systemctl --user status mms-log-inspect.service` and
+`journalctl --user -u mms-log-inspect.service`.
+
+### Testing Policies Locally
+
+Use `scripts/generate-test-corpus` to create deterministic JSONL logs, then run
+the same inspector against those files before deploying policy changes:
+
+```bash
+scripts/generate-test-corpus \
+  --scenario faulty \
+  --entries 40 \
+  --output /tmp/mms-faulty.jsonl
+
+scripts/mms-log-inspect \
+  --input-jsonl /tmp/mms-faulty.jsonl \
+  --policy examples/log-policies \
+  --output-json /tmp/mms-log-report.json \
+  --fail-on critical
+
+python3 -m json.tool /tmp/mms-log-report.json
+```
+
+Available scenarios are `clean`, `faulty`, and `adversarial`. Use `clean` to
+check false positives, `faulty` to confirm expected detections, and
+`adversarial` to review near-miss log lines that should not trigger policies.
 
 ## Health Checks
 
 ```bash
 # Loki readiness
 podman exec grafana curl -s http://loki:3100/ready
+curl -sf http://127.0.0.1:3100/ready
 
 # Prometheus targets
 curl -sf http://localhost:9090/api/v1/targets | python3 -m json.tool

--- a/docs/wiki/Observability.md
+++ b/docs/wiki/Observability.md
@@ -154,7 +154,7 @@ Run an inspection manually against Loki:
 ```bash
 ~/config/logging/bin/mms-log-inspect \
   --loki-url http://localhost:3100 \
-  --lookback-minutes 15 \
+  --lookback-minutes 60 \
   --query-limit 5000 \
   --policy ~/config/logging/inspection/policies \
   --output-json ~/config/logging/inspection/latest-report.json \

--- a/examples/log-policies/auth-failures.json
+++ b/examples/log-policies/auth-failures.json
@@ -1,0 +1,15 @@
+{
+  "name": "auth-failures",
+  "description": "Detect repeated authentication or API key failures.",
+  "window_minutes": 60,
+  "rules": [
+    {
+      "id": "repeated-auth-failure",
+      "severity": "warning",
+      "description": "A service is repeatedly rejecting credentials or API keys.",
+      "service": "*",
+      "patterns": ["authentication failed", "invalid api key", "unauthorized"],
+      "threshold": 3
+    }
+  ]
+}

--- a/examples/log-policies/error-patterns.json
+++ b/examples/log-policies/error-patterns.json
@@ -1,0 +1,15 @@
+{
+  "name": "error-patterns",
+  "description": "Detect repeated application errors in MMS service logs.",
+  "window_minutes": 60,
+  "rules": [
+    {
+      "id": "application-errors",
+      "severity": "warning",
+      "description": "A service is repeatedly logging errors, exceptions, or fatal failures.",
+      "service": "*",
+      "patterns": ["\\berror\\b", "exception", "fatal", "panic"],
+      "threshold": 3
+    }
+  ]
+}

--- a/examples/log-policies/storage-pressure.json
+++ b/examples/log-policies/storage-pressure.json
@@ -1,0 +1,15 @@
+{
+  "name": "storage-pressure",
+  "description": "Detect log messages that indicate storage exhaustion.",
+  "window_minutes": 60,
+  "rules": [
+    {
+      "id": "disk-full",
+      "severity": "critical",
+      "description": "A service reports that disk space is exhausted.",
+      "service": "*",
+      "patterns": ["no space left on device", "ENOSPC", "disk full"],
+      "threshold": 1
+    }
+  ]
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ molecule-plugins[docker]>=24.0
 pre-commit>=3.0
 proxmoxer>=2.0
 requests>=2.30
+pytest==9.0.3

--- a/roles/logging/defaults/main.yml
+++ b/roles/logging/defaults/main.yml
@@ -16,6 +16,7 @@ logging_config_dir: "{{ mms_config_dir }}/logging"
 logging_loki_data_dir: "{{ mms_config_dir }}/logging/loki-data"
 logging_grafana_data_dir: "{{ mms_config_dir }}/logging/grafana-data"
 logging_prometheus_data_dir: "{{ mms_config_dir }}/logging/prometheus-data"
+logging_systemd_user_dir: "{{ mms_home }}/.config/systemd/user"
 
 # Prometheus
 logging_prometheus_retention: "30d"
@@ -41,7 +42,7 @@ logging_alert_restart_count: 3           # restarts in 15m = crash loop
 # Periodic log inspection
 logging_inspection_enabled: true
 logging_inspection_schedule: "*-*-* *:00/15:00"
-logging_inspection_lookback_minutes: 15
+logging_inspection_lookback_minutes: 60
 logging_inspection_query_limit: 5000
 logging_inspection_fail_on: critical
 logging_inspection_policy_dir: "{{ logging_config_dir }}/inspection/policies"

--- a/roles/logging/defaults/main.yml
+++ b/roles/logging/defaults/main.yml
@@ -37,3 +37,12 @@ logging_journal_path: "/var/log/journal"
 logging_alert_error_rate_threshold: 10   # errors per 5m
 logging_alert_silence_minutes: 15        # no logs = possibly down
 logging_alert_restart_count: 3           # restarts in 15m = crash loop
+
+# Periodic log inspection
+logging_inspection_enabled: true
+logging_inspection_schedule: "*-*-* *:00/15:00"
+logging_inspection_lookback_minutes: 15
+logging_inspection_query_limit: 5000
+logging_inspection_fail_on: critical
+logging_inspection_policy_dir: "{{ logging_config_dir }}/inspection/policies"
+logging_inspection_output_file: "{{ logging_config_dir }}/inspection/latest-report.json"

--- a/roles/logging/handlers/main.yml
+++ b/roles/logging/handlers/main.yml
@@ -51,3 +51,13 @@
   become: true
   become_user: "{{ mms_user }}"
   environment: "{{ mms_systemd_env }}"
+
+- name: Restart log inspection timer
+  ansible.builtin.systemd:
+    name: mms-log-inspect.timer
+    state: restarted
+    scope: user
+  become: true
+  become_user: "{{ mms_user }}"
+  environment: "{{ mms_systemd_env }}"
+  when: logging_inspection_enabled | bool

--- a/roles/logging/tasks/containers.yml
+++ b/roles/logging/tasks/containers.yml
@@ -160,3 +160,25 @@
   become_user: "{{ mms_user }}"
   environment: "{{ mms_systemd_env }}"
   when: not ansible_check_mode
+
+- name: Enable and start log inspection timer
+  ansible.builtin.systemd:
+    name: mms-log-inspect.timer
+    enabled: true
+    state: started
+    scope: user
+  become: true
+  become_user: "{{ mms_user }}"
+  environment: "{{ mms_systemd_env }}"
+  when: logging_inspection_enabled | bool
+
+- name: Disable log inspection timer
+  ansible.builtin.systemd:
+    name: mms-log-inspect.timer
+    enabled: false
+    state: stopped
+    scope: user
+  become: true
+  become_user: "{{ mms_user }}"
+  environment: "{{ mms_systemd_env }}"
+  when: not logging_inspection_enabled | bool

--- a/roles/logging/tasks/setup.yml
+++ b/roles/logging/tasks/setup.yml
@@ -63,6 +63,15 @@
     - "{{ logging_prometheus_data_dir }}"
     - "{{ logging_config_dir }}/alloy-data"
 
+- name: Create logging systemd user directory
+  ansible.builtin.file:
+    path: "{{ logging_systemd_user_dir }}"
+    state: directory
+    owner: "{{ mms_user }}"
+    group: "{{ mms_user }}"
+    mode: "0755"
+  become: true
+
 - name: Deploy log inspection script
   ansible.builtin.copy:
     src: "{{ playbook_dir }}/../scripts/mms-log-inspect"
@@ -84,7 +93,7 @@
 - name: Deploy log inspection service
   ansible.builtin.template:
     src: mms-log-inspect.service.j2
-    dest: "{{ mms_quadlet_dir }}/mms-log-inspect.service"
+    dest: "{{ logging_systemd_user_dir }}/mms-log-inspect.service"
     owner: "{{ mms_user }}"
     group: "{{ mms_user }}"
     mode: "0644"
@@ -95,7 +104,7 @@
 - name: Deploy log inspection timer
   ansible.builtin.template:
     src: mms-log-inspect.timer.j2
-    dest: "{{ mms_quadlet_dir }}/mms-log-inspect.timer"
+    dest: "{{ logging_systemd_user_dir }}/mms-log-inspect.timer"
     owner: "{{ mms_user }}"
     group: "{{ mms_user }}"
     mode: "0644"

--- a/roles/logging/tasks/setup.yml
+++ b/roles/logging/tasks/setup.yml
@@ -55,10 +55,54 @@
     - "{{ logging_config_dir }}/grafana/provisioning/dashboards"
     - "{{ logging_config_dir }}/grafana/dashboards"
     - "{{ logging_config_dir }}/prometheus"
+    - "{{ logging_config_dir }}/bin"
+    - "{{ logging_config_dir }}/inspection"
+    - "{{ logging_inspection_policy_dir }}"
     - "{{ logging_loki_data_dir }}"
     - "{{ logging_grafana_data_dir }}"
     - "{{ logging_prometheus_data_dir }}"
     - "{{ logging_config_dir }}/alloy-data"
+
+- name: Deploy log inspection script
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../scripts/mms-log-inspect"
+    dest: "{{ logging_config_dir }}/bin/mms-log-inspect"
+    owner: "{{ mms_user }}"
+    group: "{{ mms_user }}"
+    mode: "0755"
+  become: true
+
+- name: Deploy example log inspection policies
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../examples/log-policies/"
+    dest: "{{ logging_inspection_policy_dir }}/"
+    owner: "{{ mms_user }}"
+    group: "{{ mms_user }}"
+    mode: "0644"
+  become: true
+
+- name: Deploy log inspection service
+  ansible.builtin.template:
+    src: mms-log-inspect.service.j2
+    dest: "{{ mms_quadlet_dir }}/mms-log-inspect.service"
+    owner: "{{ mms_user }}"
+    group: "{{ mms_user }}"
+    mode: "0644"
+  become: true
+  notify:
+    - Reload systemd user daemon
+
+- name: Deploy log inspection timer
+  ansible.builtin.template:
+    src: mms-log-inspect.timer.j2
+    dest: "{{ mms_quadlet_dir }}/mms-log-inspect.timer"
+    owner: "{{ mms_user }}"
+    group: "{{ mms_user }}"
+    mode: "0644"
+  become: true
+  notify:
+    - Reload systemd user daemon
+    - Restart log inspection timer
 
 # Deploy Alloy config
 - name: Deploy Alloy config

--- a/roles/logging/templates/loki.container.j2
+++ b/roles/logging/templates/loki.container.j2
@@ -8,6 +8,7 @@ After=network-online.target
 ContainerName=loki
 Image={{ logging_loki_image }}
 Network={{ mms_network_name }}.network
+PublishPort=127.0.0.1:3100:3100
 Exec=-config.file=/etc/loki/loki-config.yml
 Volume={{ logging_config_dir }}/loki/loki-config.yml:/etc/loki/loki-config.yml:Z,ro
 Volume={{ logging_config_dir }}/loki/rules:/etc/loki/rules:Z,ro

--- a/roles/logging/templates/mms-log-inspect.service.j2
+++ b/roles/logging/templates/mms-log-inspect.service.j2
@@ -1,0 +1,9 @@
+{{ ansible_managed | comment }}
+
+[Unit]
+Description=Inspect MMS container logs for policy matches
+After=loki.service
+
+[Service]
+Type=oneshot
+ExecStart={{ logging_config_dir }}/bin/mms-log-inspect --loki-url http://localhost:3100 --lookback-minutes {{ logging_inspection_lookback_minutes }} --query-limit {{ logging_inspection_query_limit }} --policy {{ logging_inspection_policy_dir }} --output-json {{ logging_inspection_output_file }} --fail-on {{ logging_inspection_fail_on }}

--- a/roles/logging/templates/mms-log-inspect.timer.j2
+++ b/roles/logging/templates/mms-log-inspect.timer.j2
@@ -1,0 +1,12 @@
+{{ ansible_managed | comment }}
+
+[Unit]
+Description=Run MMS log inspection on a schedule
+
+[Timer]
+OnCalendar={{ logging_inspection_schedule }}
+Persistent=true
+Unit=mms-log-inspect.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Generate deterministic JSONL log corpora for log inspection tests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Iterable
+
+
+SERVICES = ("radarr", "sonarr", "sabnzbd", "jellyfin")
+
+CLEAN_MESSAGES = (
+    "health check completed successfully",
+    "scheduled task completed",
+    "media library scan finished",
+    "configuration loaded",
+)
+
+FAULT_MESSAGES = (
+    "error opening database connection",
+    "Unhandled exception while importing metadata",
+    "authentication failed for API client",
+    "invalid api key rejected",
+    "write failed: no space left on device",
+)
+
+ADVERSARIAL_MESSAGES = (
+    "terror movie metadata imported",
+    "the authentication workflow completed",
+    "the invalid credential documentation page was viewed",
+    "spacious device path selected",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scenario",
+        choices=("clean", "faulty", "adversarial"),
+        required=True,
+        help="Corpus scenario to generate.",
+    )
+    parser.add_argument(
+        "--entries",
+        type=int,
+        default=24,
+        help="Number of log entries to write.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Destination JSONL file.",
+    )
+    return parser.parse_args()
+
+
+def message_pool(scenario: str) -> tuple[str, ...]:
+    if scenario == "clean":
+        return CLEAN_MESSAGES
+    if scenario == "faulty":
+        return CLEAN_MESSAGES + FAULT_MESSAGES
+    return CLEAN_MESSAGES + ADVERSARIAL_MESSAGES
+
+
+def generate_entries(scenario: str, count: int) -> Iterable[dict[str, str]]:
+    base_time = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+    messages = message_pool(scenario)
+    for index in range(count):
+        service = SERVICES[index % len(SERVICES)]
+        timestamp = base_time + timedelta(seconds=index * 30)
+        yield {
+            "timestamp": timestamp.isoformat().replace("+00:00", "Z"),
+            "service": service,
+            "unit": f"{service}.service",
+            "message": messages[index % len(messages)],
+        }
+
+
+def main() -> int:
+    args = parse_args()
+    if args.entries < 1:
+        raise SystemExit("--entries must be greater than zero")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as handle:
+        for entry in generate_entries(args.scenario, args.entries):
+            handle.write(json.dumps(entry, sort_keys=True))
+            handle.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate-test-corpus
+++ b/scripts/generate-test-corpus
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterable
 
@@ -67,7 +67,7 @@ def message_pool(scenario: str) -> tuple[str, ...]:
 
 
 def generate_entries(scenario: str, count: int) -> Iterable[dict[str, str]]:
-    base_time = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+    base_time = datetime(2026, 5, 10, 12, 0, tzinfo=timezone.utc)
     messages = message_pool(scenario)
     for index in range(count):
         service = SERVICES[index % len(SERVICES)]

--- a/scripts/mms-log-inspect
+++ b/scripts/mms-log-inspect
@@ -11,7 +11,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -171,7 +171,7 @@ def load_entries(path: Path) -> list[dict[str, Any]]:
 def loki_time_range(lookback_minutes: int) -> tuple[str, str]:
     if lookback_minutes < 1:
         raise ValueError("--lookback-minutes must be greater than zero")
-    end = datetime.now(tz=UTC)
+    end = datetime.now(tz=timezone.utc)
     start = end - timedelta(minutes=lookback_minutes)
     return str(int(start.timestamp() * 1_000_000_000)), str(int(end.timestamp() * 1_000_000_000))
 
@@ -289,7 +289,7 @@ def summarize(findings: Iterable[dict[str, Any]]) -> dict[str, int]:
 
 def write_report(path: Path, findings: list[dict[str, Any]]) -> None:
     report = {
-        "generated_at": datetime.now(tz=UTC).isoformat().replace("+00:00", "Z"),
+        "generated_at": datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z"),
         "summary": summarize(findings),
         "findings": findings,
     }

--- a/scripts/mms-log-inspect
+++ b/scripts/mms-log-inspect
@@ -7,8 +7,11 @@ import argparse
 import json
 import re
 import sys
+import urllib.error
+import urllib.parse
+import urllib.request
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -43,6 +46,19 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--input-jsonl", type=Path, help="Local JSONL log corpus.")
     parser.add_argument("--policy", action="append", type=Path, required=True)
     parser.add_argument("--output-json", type=Path, required=True)
+    parser.add_argument("--loki-url", help="Base URL for Loki.")
+    parser.add_argument(
+        "--lookback-minutes",
+        type=int,
+        default=15,
+        help="Minutes of Loki logs to inspect.",
+    )
+    parser.add_argument(
+        "--query-limit",
+        type=int,
+        default=5000,
+        help="Maximum Loki log entries to query.",
+    )
     parser.add_argument(
         "--fail-on",
         choices=tuple(SEVERITY_ORDER),
@@ -122,6 +138,22 @@ def load_policy(path: Path) -> Policy:
     )
 
 
+def expand_policy_paths(paths: Iterable[Path]) -> list[Path]:
+    expanded = []
+    for path in paths:
+        if path.is_dir():
+            expanded.extend(sorted(path.glob("*.json")))
+        else:
+            expanded.append(path)
+    if not expanded:
+        raise PolicyError("Invalid policy: no policy files found")
+    return expanded
+
+
+def load_policies(paths: Iterable[Path]) -> list[Policy]:
+    return [load_policy(path) for path in expand_policy_paths(paths)]
+
+
 def load_entries(path: Path) -> list[dict[str, Any]]:
     entries = []
     with path.open(encoding="utf-8") as handle:
@@ -134,6 +166,72 @@ def load_entries(path: Path) -> list[dict[str, Any]]:
             if isinstance(entry, dict):
                 entries.append(entry)
     return entries
+
+
+def loki_time_range(lookback_minutes: int) -> tuple[str, str]:
+    if lookback_minutes < 1:
+        raise ValueError("--lookback-minutes must be greater than zero")
+    end = datetime.now(tz=UTC)
+    start = end - timedelta(minutes=lookback_minutes)
+    return str(int(start.timestamp() * 1_000_000_000)), str(int(end.timestamp() * 1_000_000_000))
+
+
+def build_loki_url(base_url: str, lookback_minutes: int, query_limit: int) -> str:
+    if query_limit < 1:
+        raise ValueError("--query-limit must be greater than zero")
+    start, end = loki_time_range(lookback_minutes)
+    query = urllib.parse.urlencode(
+        {
+            "query": '{job="mms"}',
+            "start": start,
+            "end": end,
+            "limit": str(query_limit),
+            "direction": "backward",
+        }
+    )
+    return f"{base_url.rstrip('/')}/loki/api/v1/query_range?{query}"
+
+
+def load_loki_entries(base_url: str, lookback_minutes: int, query_limit: int) -> list[dict[str, Any]]:
+    url = build_loki_url(base_url, lookback_minutes, query_limit)
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.loads(response.read().decode())
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
+        raise ValueError(f"Loki query failed: {error}") from error
+    return parse_loki_payload(payload)
+
+
+def parse_loki_payload(payload: object) -> list[dict[str, Any]]:
+    data = require_mapping(require_mapping(payload, "Loki response").get("data"), "Loki data")
+    result = data.get("result")
+    if not isinstance(result, list):
+        raise ValueError("Loki query failed: response data.result must be a list")
+
+    entries = []
+    for stream in result:
+        stream_data = require_mapping(stream, "Loki stream")
+        labels = require_mapping(stream_data.get("stream"), "Loki stream labels")
+        values = stream_data.get("values")
+        if not isinstance(values, list):
+            continue
+        for value in values:
+            if isinstance(value, list) and len(value) == 2:
+                entries.append(loki_value_to_entry(labels, value))
+    return entries
+
+
+def loki_value_to_entry(labels: dict[str, Any], value: list[object]) -> dict[str, str]:
+    timestamp, message = value
+    service = str(labels.get("service_name") or labels.get("container") or "")
+    unit = str(labels.get("unit") or labels.get("__journal__systemd_user_unit") or "")
+    return {
+        "timestamp": str(timestamp),
+        "service": service,
+        "unit": unit,
+        "message": str(message),
+    }
 
 
 def service_matches(rule_service: str, entry: dict[str, Any]) -> bool:
@@ -206,13 +304,16 @@ def has_failure(findings: Iterable[dict[str, Any]], fail_on: str) -> bool:
 
 def main() -> int:
     args = parse_args()
-    if args.input_jsonl is None:
-        print("--input-jsonl is required", file=sys.stderr)
+    if bool(args.input_jsonl) == bool(args.loki_url):
+        print("Provide exactly one of --input-jsonl or --loki-url", file=sys.stderr)
         return 2
 
     try:
-        policies = [load_policy(path) for path in args.policy]
-        entries = load_entries(args.input_jsonl)
+        policies = load_policies(args.policy)
+        if args.input_jsonl:
+            entries = load_entries(args.input_jsonl)
+        else:
+            entries = load_loki_entries(args.loki_url, args.lookback_minutes, args.query_limit)
         findings = evaluate_policies(policies, entries)
     except (OSError, PolicyError, ValueError) as error:
         print(error, file=sys.stderr)

--- a/scripts/mms-log-inspect
+++ b/scripts/mms-log-inspect
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Inspect MMS logs with JSON policy files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SEVERITY_ORDER = {"info": 0, "warning": 1, "critical": 2}
+
+
+class PolicyError(ValueError):
+    """Raised when a policy file cannot be evaluated safely."""
+
+
+@dataclass(frozen=True)
+class Rule:
+    id: str
+    severity: str
+    description: str
+    service: str
+    patterns: tuple[re.Pattern[str], ...]
+    threshold: int
+
+
+@dataclass(frozen=True)
+class Policy:
+    name: str
+    description: str
+    window_minutes: int
+    rules: tuple[Rule, ...]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-jsonl", type=Path, help="Local JSONL log corpus.")
+    parser.add_argument("--policy", action="append", type=Path, required=True)
+    parser.add_argument("--output-json", type=Path, required=True)
+    parser.add_argument(
+        "--fail-on",
+        choices=tuple(SEVERITY_ORDER),
+        default="critical",
+        help="Exit 1 when findings at this severity or above exist.",
+    )
+    return parser.parse_args()
+
+
+def require_mapping(value: object, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise PolicyError(f"Invalid policy: {context} must be an object")
+    return value
+
+
+def require_string(mapping: dict[str, Any], key: str, context: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise PolicyError(f"Invalid policy: {context} requires string field {key}")
+    return value
+
+
+def require_positive_int(mapping: dict[str, Any], key: str, context: str) -> int:
+    value = mapping.get(key)
+    if not isinstance(value, int) or value < 1:
+        raise PolicyError(f"Invalid policy: {context} requires positive integer {key}")
+    return value
+
+
+def load_rule(raw_rule: object, index: int) -> Rule:
+    rule = require_mapping(raw_rule, f"rules[{index}]")
+    rule_id = require_string(rule, "id", f"rules[{index}]")
+    context = f"rule {rule_id}"
+    severity = require_string(rule, "severity", context)
+    if severity not in SEVERITY_ORDER:
+        raise PolicyError(f"Invalid policy: {context} has unsupported severity {severity}")
+
+    raw_patterns = rule.get("patterns")
+    if not isinstance(raw_patterns, list) or not raw_patterns:
+        raise PolicyError(f"Invalid policy: {context} requires non-empty patterns")
+
+    patterns = []
+    for pattern in raw_patterns:
+        if not isinstance(pattern, str) or not pattern:
+            raise PolicyError(f"Invalid policy: {context} has an empty pattern")
+        try:
+            patterns.append(re.compile(pattern, re.IGNORECASE))
+        except re.error as error:
+            raise PolicyError(f"Invalid policy: {context} has invalid regex {pattern}") from error
+
+    return Rule(
+        id=rule_id,
+        severity=severity,
+        description=require_string(rule, "description", context),
+        service=require_string(rule, "service", context),
+        patterns=tuple(patterns),
+        threshold=require_positive_int(rule, "threshold", context),
+    )
+
+
+def load_policy(path: Path) -> Policy:
+    try:
+        raw_policy = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise PolicyError(f"Invalid policy: {path} is not valid JSON") from error
+
+    policy = require_mapping(raw_policy, str(path))
+    raw_rules = policy.get("rules")
+    if not isinstance(raw_rules, list) or not raw_rules:
+        raise PolicyError(f"Invalid policy: {path} requires non-empty rules")
+
+    return Policy(
+        name=require_string(policy, "name", str(path)),
+        description=require_string(policy, "description", str(path)),
+        window_minutes=require_positive_int(policy, "window_minutes", str(path)),
+        rules=tuple(load_rule(rule, index) for index, rule in enumerate(raw_rules)),
+    )
+
+
+def load_entries(path: Path) -> list[dict[str, Any]]:
+    entries = []
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError as error:
+                message = f"{path}:{line_number} is not valid JSONL"
+                raise ValueError(message) from error
+            if isinstance(entry, dict):
+                entries.append(entry)
+    return entries
+
+
+def service_matches(rule_service: str, entry: dict[str, Any]) -> bool:
+    if rule_service == "*":
+        return True
+    return rule_service in {entry.get("service"), entry.get("unit")}
+
+
+def matching_entries(rule: Rule, entries: Iterable[dict[str, Any]]) -> list[dict[str, str]]:
+    matches = []
+    for entry in entries:
+        message = str(entry.get("message", ""))
+        if service_matches(rule.service, entry) and any(p.search(message) for p in rule.patterns):
+            matches.append(
+                {
+                    "timestamp": str(entry.get("timestamp", "")),
+                    "service": str(entry.get("service", "")),
+                    "unit": str(entry.get("unit", "")),
+                    "message": message,
+                }
+            )
+    return matches
+
+
+def evaluate_policies(
+    policies: Iterable[Policy],
+    entries: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    findings = []
+    for policy in policies:
+        for rule in policy.rules:
+            matches = matching_entries(rule, entries)
+            if len(matches) >= rule.threshold:
+                findings.append(
+                    {
+                        "policy": policy.name,
+                        "rule_id": rule.id,
+                        "severity": rule.severity,
+                        "description": rule.description,
+                        "match_count": len(matches),
+                        "threshold": rule.threshold,
+                        "matches": matches[:10],
+                    }
+                )
+    return findings
+
+
+def summarize(findings: Iterable[dict[str, Any]]) -> dict[str, int]:
+    summary = {"critical": 0, "warning": 0, "info": 0}
+    for finding in findings:
+        severity = str(finding["severity"])
+        summary[severity] += 1
+    return summary
+
+
+def write_report(path: Path, findings: list[dict[str, Any]]) -> None:
+    report = {
+        "generated_at": datetime.now(tz=UTC).isoformat().replace("+00:00", "Z"),
+        "summary": summarize(findings),
+        "findings": findings,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def has_failure(findings: Iterable[dict[str, Any]], fail_on: str) -> bool:
+    minimum = SEVERITY_ORDER[fail_on]
+    return any(SEVERITY_ORDER[str(finding["severity"])] >= minimum for finding in findings)
+
+
+def main() -> int:
+    args = parse_args()
+    if args.input_jsonl is None:
+        print("--input-jsonl is required", file=sys.stderr)
+        return 2
+
+    try:
+        policies = [load_policy(path) for path in args.policy]
+        entries = load_entries(args.input_jsonl)
+        findings = evaluate_policies(policies, entries)
+    except (OSError, PolicyError, ValueError) as error:
+        print(error, file=sys.stderr)
+        return 2
+
+    write_report(args.output_json, findings)
+    return 1 if has_failure(findings, args.fail_on) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/logging/test_log_inspection.py
+++ b/tests/logging/test_log_inspection.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GENERATE_CORPUS = REPO_ROOT / "scripts" / "generate-test-corpus"
+INSPECT_LOGS = REPO_ROOT / "scripts" / "mms-log-inspect"
+
+
+def run_command(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def write_policy(path: Path) -> None:
+    policy = {
+        "name": "functional-test-policy",
+        "description": "Detect common container log failures.",
+        "window_minutes": 60,
+        "rules": [
+            {
+                "id": "storage-full",
+                "severity": "critical",
+                "description": "Storage exhaustion blocks writes.",
+                "service": "*",
+                "patterns": ["no space left on device", "ENOSPC"],
+                "threshold": 1,
+            },
+            {
+                "id": "auth-failure",
+                "severity": "warning",
+                "description": "Repeated authentication failures.",
+                "service": "*",
+                "patterns": ["authentication failed", "invalid api key"],
+                "threshold": 2,
+            },
+            {
+                "id": "application-error",
+                "severity": "warning",
+                "description": "Application error or exception.",
+                "service": "*",
+                "patterns": ["\\berror\\b", "exception", "fatal"],
+                "threshold": 2,
+            },
+        ],
+    }
+    path.write_text(json.dumps(policy), encoding="utf-8")
+
+
+def read_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_clean_corpus_has_no_findings(tmp_path: Path) -> None:
+    corpus = tmp_path / "clean.jsonl"
+    policy = tmp_path / "policy.json"
+    report = tmp_path / "report.json"
+    write_policy(policy)
+
+    generated = run_command(
+        str(GENERATE_CORPUS),
+        "--scenario",
+        "clean",
+        "--entries",
+        "24",
+        "--output",
+        str(corpus),
+    )
+    assert generated.returncode == 0, generated.stderr
+
+    inspected = run_command(
+        str(INSPECT_LOGS),
+        "--input-jsonl",
+        str(corpus),
+        "--policy",
+        str(policy),
+        "--output-json",
+        str(report),
+        "--fail-on",
+        "critical",
+    )
+
+    assert inspected.returncode == 0, inspected.stderr
+    result = read_json(report)
+    assert result["summary"] == {"critical": 0, "warning": 0, "info": 0}
+    assert result["findings"] == []
+
+
+def test_faulty_corpus_reports_policy_findings(tmp_path: Path) -> None:
+    corpus = tmp_path / "faulty.jsonl"
+    policy = tmp_path / "policy.json"
+    report = tmp_path / "report.json"
+    write_policy(policy)
+
+    generated = run_command(
+        str(GENERATE_CORPUS),
+        "--scenario",
+        "faulty",
+        "--entries",
+        "40",
+        "--output",
+        str(corpus),
+    )
+    assert generated.returncode == 0, generated.stderr
+
+    inspected = run_command(
+        str(INSPECT_LOGS),
+        "--input-jsonl",
+        str(corpus),
+        "--policy",
+        str(policy),
+        "--output-json",
+        str(report),
+        "--fail-on",
+        "critical",
+    )
+
+    assert inspected.returncode == 1, inspected.stderr
+    result = read_json(report)
+    finding_ids = {finding["rule_id"] for finding in result["findings"]}
+    assert finding_ids == {"application-error", "auth-failure", "storage-full"}
+    assert result["summary"] == {"critical": 1, "warning": 2, "info": 0}
+
+
+def test_adversarial_corpus_does_not_match_substrings(tmp_path: Path) -> None:
+    corpus = tmp_path / "adversarial.jsonl"
+    policy = tmp_path / "policy.json"
+    report = tmp_path / "report.json"
+    write_policy(policy)
+
+    generated = run_command(
+        str(GENERATE_CORPUS),
+        "--scenario",
+        "adversarial",
+        "--entries",
+        "24",
+        "--output",
+        str(corpus),
+    )
+    assert generated.returncode == 0, generated.stderr
+
+    inspected = run_command(
+        str(INSPECT_LOGS),
+        "--input-jsonl",
+        str(corpus),
+        "--policy",
+        str(policy),
+        "--output-json",
+        str(report),
+    )
+
+    assert inspected.returncode == 0, inspected.stderr
+    result = read_json(report)
+    assert result["findings"] == []
+
+
+def test_malformed_policy_returns_actionable_error(tmp_path: Path) -> None:
+    corpus = tmp_path / "clean.jsonl"
+    policy = tmp_path / "malformed.json"
+    report = tmp_path / "report.json"
+    policy.write_text(
+        json.dumps(
+            {
+                "name": "broken-policy",
+                "description": "Invalid regex policy.",
+                "window_minutes": 60,
+                "rules": [
+                    {
+                        "id": "broken",
+                        "severity": "warning",
+                        "description": "Malformed regex.",
+                        "service": "*",
+                        "patterns": ["["],
+                        "threshold": 1,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    generated = run_command(
+        str(GENERATE_CORPUS),
+        "--scenario",
+        "clean",
+        "--entries",
+        "4",
+        "--output",
+        str(corpus),
+    )
+    assert generated.returncode == 0, generated.stderr
+
+    inspected = run_command(
+        str(INSPECT_LOGS),
+        "--input-jsonl",
+        str(corpus),
+        "--policy",
+        str(policy),
+        "--output-json",
+        str(report),
+    )
+
+    assert inspected.returncode == 2
+    assert "Invalid policy" in inspected.stderr
+    assert "broken" in inspected.stderr

--- a/tests/logging/test_log_inspection.py
+++ b/tests/logging/test_log_inspection.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from threading import Thread
+from urllib.parse import parse_qs, urlparse
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -59,6 +62,51 @@ def write_policy(path: Path) -> None:
 
 def read_json(path: Path) -> dict[str, object]:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+class LokiHandler(BaseHTTPRequestHandler):
+    requested_query = ""
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        params = parse_qs(parsed.query)
+        LokiHandler.requested_query = params.get("query", [""])[0]
+        payload = {
+            "status": "success",
+            "data": {
+                "resultType": "streams",
+                "result": [
+                    {
+                        "stream": {
+                            "service_name": "radarr",
+                            "unit": "radarr.service",
+                        },
+                        "values": [
+                            ["1770000000000000000", "fatal import exception"],
+                            ["1770000000500000000", "error syncing release metadata"],
+                            ["1770000001000000000", "no space left on device"],
+                        ],
+                    }
+                ],
+            },
+        }
+        body = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
+def loki_server() -> tuple[ThreadingHTTPServer, str]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), LokiHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    return server, f"http://{host}:{port}"
 
 
 def test_clean_corpus_has_no_findings(tmp_path: Path) -> None:
@@ -213,3 +261,33 @@ def test_malformed_policy_returns_actionable_error(tmp_path: Path) -> None:
     assert inspected.returncode == 2
     assert "Invalid policy" in inspected.stderr
     assert "broken" in inspected.stderr
+
+
+def test_loki_mode_evaluates_query_range_results(tmp_path: Path) -> None:
+    policy = tmp_path / "policy.json"
+    report = tmp_path / "report.json"
+    write_policy(policy)
+    server, loki_url = loki_server()
+
+    try:
+        inspected = run_command(
+            str(INSPECT_LOGS),
+            "--loki-url",
+            loki_url,
+            "--lookback-minutes",
+            "15",
+            "--policy",
+            str(policy),
+            "--output-json",
+            str(report),
+            "--fail-on",
+            "critical",
+        )
+    finally:
+        server.shutdown()
+
+    assert inspected.returncode == 1, inspected.stderr
+    result = read_json(report)
+    finding_ids = {finding["rule_id"] for finding in result["findings"]}
+    assert finding_ids == {"application-error", "storage-full"}
+    assert LokiHandler.requested_query == '{job="mms"}'


### PR DESCRIPTION
## Summary

- Adds `scripts/mms-log-inspect`, a dependency-free policy inspector that can evaluate generated JSONL corpora or live Loki `query_range` results.
- Adds `scripts/generate-test-corpus` plus functional tests and example policy files for application errors, storage pressure, and authentication failures.
- Deploys a rootless `mms-log-inspect.service` and `mms-log-inspect.timer` through the logging role, with Loki published on `127.0.0.1:3100` for host-local inspection.
- Documents policy authoring, manual runs, generated-corpus validation, and the latest report location.

Closes #21.

## Verification

- `.venv/bin/python -m pytest -q tests/logging/test_log_inspection.py` -> 5 passed
- `make lint` -> 0 failures, 0 warnings
- `source .venv/bin/activate && ansible-playbook playbooks/deploy-service.yml -e service_name=logging --syntax-check` -> syntax check passed
- `scripts/generate-test-corpus --scenario faulty --entries 40 ...` followed by `scripts/mms-log-inspect --input-jsonl ... --policy examples/log-policies ... --fail-on critical` -> exited 1 for expected critical finding and produced valid JSON

## Adversarial Review

Plan and code review notes are recorded in `docs/superpowers/reviews/2026-05-10-log-inspection-issue-21.md`.

Review findings addressed in this branch:

- The inspector uses only Python standard library APIs and JSON policies, avoiding new target-host runtime dependencies.
- Loki is bound to loopback only, so the host-side timer can query it without exposing Loki on the LAN.
- The systemd service and timer are installed in `~/.config/systemd/user`, not the Quadlet directory.
- The default inspection lookback matches the example policy windows.
- The scripts use `timezone.utc` instead of `datetime.UTC` for older Python compatibility.

## Deferred Work

None. No follow-up issues were filed.
