### PR TITLE
feat(logging): add notification support for issues

### DIFF
--- a/docs/superpowers/plans/2026-05-10-notification-support-issue-88.md
+++ b/docs/superpowers/plans/2026-05-10-notification-support-issue-88.md
@@ -16,8 +16,9 @@
   webhook delivery, `--notify`, and notification-aware exit handling.
 - `tests/logging/test_log_inspection.py`: add functional tests using
   `scripts/generate-test-corpus` and local HTTP webhook receivers.
-- `examples/log-policies/notification-webhooks.json`: demonstrate Discord,
-  Slack, and generic webhook targets with environment-variable references.
+- `examples/log-notification-policies/notification-webhooks.json`: demonstrate
+  Discord, Slack, and generic webhook targets with environment-variable
+  references outside the actively deployed policy directory.
 - `roles/logging/defaults/main.yml`: add notification deployment defaults.
 - `roles/logging/tasks/setup.yml`: create a private notification environment
   file without overwriting operator secrets.
@@ -66,8 +67,9 @@
 
 ### Task 4: Examples, Docs, and Adversarial Review
 
-- [ ] Add `examples/log-policies/notification-webhooks.json` with Discord,
-  Slack, and generic webhook examples using environment-variable names only.
+- [ ] Add `examples/log-notification-policies/notification-webhooks.json` with
+  Discord, Slack, and generic webhook examples using environment-variable names
+  only.
 - [ ] Update `docs/wiki/Observability.md` with policy syntax, secret setup,
   generated-corpus testing, and manual run examples.
 - [ ] Write `docs/superpowers/reviews/2026-05-10-notification-support-issue-88.md`

--- a/docs/superpowers/plans/2026-05-10-notification-support-issue-88.md
+++ b/docs/superpowers/plans/2026-05-10-notification-support-issue-88.md
@@ -1,0 +1,86 @@
+# Notification Support for Issue 88 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Notify operators through webhook targets when log inspection policies produce findings.
+
+**Architecture:** Extend the existing dependency-free Python inspector with policy-defined notification targets and provider-specific payload builders. Keep secrets in environment variables, wire scheduled runs through systemd only when explicitly enabled, and verify behavior with generated JSONL corpora plus local webhook servers.
+
+**Tech Stack:** Python standard library, pytest, Ansible templates, JSON policy files, systemd user units.
+
+---
+
+## File Structure
+
+- `scripts/mms-log-inspect`: add notification policy parsing, payload building,
+  webhook delivery, `--notify`, and notification-aware exit handling.
+- `tests/logging/test_log_inspection.py`: add functional tests using
+  `scripts/generate-test-corpus` and local HTTP webhook receivers.
+- `examples/log-policies/notification-webhooks.json`: demonstrate Discord,
+  Slack, and generic webhook targets with environment-variable references.
+- `roles/logging/defaults/main.yml`: add notification deployment defaults.
+- `roles/logging/tasks/setup.yml`: create a private notification environment
+  file without overwriting operator secrets.
+- `roles/logging/templates/mms-log-inspect.service.j2`: include optional
+  `EnvironmentFile=` and `--notify`.
+- `docs/wiki/Observability.md`: document how to enable, configure, test, and
+  operate notifications.
+- `docs/superpowers/reviews/2026-05-10-notification-support-issue-88.md`:
+  adversarial plan and code review notes.
+
+## Tasks
+
+### Task 1: Notification Policy Parsing
+
+- [ ] Add failing tests for valid notification blocks and unsupported providers.
+- [ ] Run `.venv/bin/python -m pytest -q tests/logging/test_log_inspection.py`
+  and verify the new tests fail because notifications are not parsed.
+- [ ] Add a `NotificationTarget` dataclass and validation for `id`, `provider`,
+  `webhook_url_env`, and `min_severity`.
+- [ ] Re-run the focused test file and verify it passes.
+- [ ] Commit with `feat(logging): parse notification targets`.
+
+### Task 2: Webhook Payloads and Delivery
+
+- [ ] Add failing tests that use `scripts/generate-test-corpus --scenario faulty`
+  and a local HTTP server to assert Discord notifications are sent for findings.
+- [ ] Add failing tests for clean and adversarial corpora asserting no webhook
+  request is sent.
+- [ ] Implement provider payload builders for `discord`, `slack`, and `generic`.
+- [ ] Implement webhook POST delivery with clear errors and no secret logging.
+- [ ] Re-run the focused test file and verify it passes.
+- [ ] Commit with `feat(logging): send webhook notifications for findings`.
+
+### Task 3: Scheduled Deployment Wiring
+
+- [ ] Add failing assertions that the service template includes notification
+  flags and environment file behavior when enabled.
+- [ ] Add defaults for disabled-by-default notification deployment.
+- [ ] Create the private `notifications.env` only when missing and with mode
+  `0600`.
+- [ ] Update the systemd service template to conditionally read the environment
+  file and pass `--notify`.
+- [ ] Run `.venv/bin/python -m pytest -q tests/logging/test_log_inspection.py`
+  and `make lint`.
+- [ ] Commit with `feat(logging): wire scheduled notification delivery`.
+
+### Task 4: Examples, Docs, and Adversarial Review
+
+- [ ] Add `examples/log-policies/notification-webhooks.json` with Discord,
+  Slack, and generic webhook examples using environment-variable names only.
+- [ ] Update `docs/wiki/Observability.md` with policy syntax, secret setup,
+  generated-corpus testing, and manual run examples.
+- [ ] Write `docs/superpowers/reviews/2026-05-10-notification-support-issue-88.md`
+  covering plan risks, code risks, test evidence, and deferred work decisions.
+- [ ] Run focused tests and `make lint`.
+- [ ] Commit with `docs(logging): document notification webhooks`.
+
+### Task 5: PR and Follow-Up Handling
+
+- [ ] Review `git diff main...HEAD` for unnecessary complexity and secret leaks.
+- [ ] Push `feat/issue-88-notifications`.
+- [ ] Open a PR that closes issue 88 and lists validation commands.
+- [ ] If review or implementation defers work, file GitHub issues for each
+  deferred item and repeat this process for those issues.
+- [ ] Shepherd the PR until merge, subject to repository permissions and remote
+  review availability.

--- a/docs/superpowers/reviews/2026-05-10-notification-support-issue-88.md
+++ b/docs/superpowers/reviews/2026-05-10-notification-support-issue-88.md
@@ -1,0 +1,43 @@
+# Notification Support Issue 88 Adversarial Review
+
+## Plan Review
+
+- Secret handling: notification policy files reference environment-variable
+  names only. Webhook URLs are not committed, rendered into reports, or printed
+  in errors.
+- Scope control: the implementation supports webhook-compatible providers only.
+  Native WhatsApp APIs were not added because they require provider-specific
+  credentials, approvals, and dependencies outside the current issue.
+- Operator control: scheduled notifications are disabled by default. Enabling
+  them is an explicit inventory/default override.
+- Local validation: tests use `scripts/generate-test-corpus` for clean, faulty,
+  and adversarial data, plus local HTTP receivers instead of external services.
+
+## Code Review
+
+- Notification sends happen after the JSON report is written, so operators keep
+  the report even when webhook delivery fails.
+- Missing webhook environment variables return exit `2` with the variable name
+  and no secret value.
+- Clean corpora and adversarial near-miss corpora do not send notifications.
+- Discord and Slack receive concise text payloads. Generic webhook targets
+  receive structured report data suitable for automation bridges.
+- The systemd user service reads the notification environment file only when
+  `logging_inspection_notifications_enabled` is true.
+- The Ansible task creates `notifications.env` with mode `0600` and
+  `force: false`, so redeploys do not overwrite operator-managed secrets.
+- Notification examples live outside `examples/log-policies/` because that
+  directory is deployed as active policy configuration by the logging role.
+
+## Verification
+
+- `.venv/bin/python -m pytest -q tests/logging/test_log_inspection.py`
+- `.venv/bin/python -m pytest -q tests/logging/test_logging_role_notifications.py`
+- `make lint`
+
+## Deferred Work
+
+None. No follow-up GitHub issues are required for issue 88. Native WhatsApp API
+support is intentionally out of scope because the generic webhook provider can
+feed WhatsApp bridge services without adding a new dependency or credential
+model.

--- a/docs/superpowers/specs/2026-05-10-notification-support-issue-88-design.md
+++ b/docs/superpowers/specs/2026-05-10-notification-support-issue-88-design.md
@@ -1,0 +1,96 @@
+# Notification Support for Issue Findings Design
+
+## Context
+
+GitHub issue 88 asks for a notification method when the policy-driven log
+inspector identifies issues. The inspector from PR 87 already evaluates JSON
+policies against generated JSONL corpora or Loki query results, writes a JSON
+report, and exits nonzero for findings at or above `--fail-on`.
+
+## Recommended Approach
+
+Add dependency-free webhook notifications to `scripts/mms-log-inspect`. Policy
+files may define notification targets with a provider, an environment-variable
+name containing the webhook URL, and a minimum severity. This keeps committed
+policy files free of secrets and lets the same mechanism work for Discord,
+Slack, and generic webhook bridges such as WhatsApp automation services.
+
+Alternatives considered:
+
+- Systemd-only notifications through `OnFailure=` would require separate unit
+  wiring per destination and would not work for local corpus validation.
+- Native SDK integrations for every service would add dependencies and secrets
+  handling complexity that the current standard-library inspector avoids.
+
+## Policy Shape
+
+Policies can include an optional top-level `notifications` array:
+
+```json
+{
+  "notifications": [
+    {
+      "id": "ops-discord",
+      "provider": "discord",
+      "webhook_url_env": "MMS_DISCORD_WEBHOOK_URL",
+      "min_severity": "warning"
+    }
+  ]
+}
+```
+
+Supported providers are `discord`, `slack`, and `generic`. `generic` sends the
+full structured report. Discord and Slack send concise text payloads accepted by
+their incoming webhook APIs.
+
+## CLI Behavior
+
+`mms-log-inspect` will add `--notify` to enable policy-defined notifications.
+By default, policy notification blocks are validated but not sent, so local test
+runs and scheduled inspections remain unchanged until operators opt in. When
+`--notify` is set, notifications are sent after the report is written if the
+report has findings at or above each target's `min_severity`.
+
+Notification delivery failures are operational failures. The command exits `2`
+after writing the report if a configured webhook environment variable is missing
+or a webhook request fails. This fail-fast behavior makes a broken notification
+path visible in `systemctl --user status mms-log-inspect.service`.
+
+## Deployment
+
+The logging role will add:
+
+- `logging_inspection_notifications_enabled`, default `false`
+- `logging_inspection_environment_file`, default
+  `{{ logging_config_dir }}/inspection/notifications.env`
+
+When notifications are enabled, the systemd service passes `--notify` and reads
+the environment file. The role creates the environment file with mode `0600` if
+it does not already exist, but does not overwrite operator-managed secrets.
+
+## Testing
+
+Functional tests will continue using `scripts/generate-test-corpus`. New tests
+will verify:
+
+- faulty corpora trigger a Discord notification when `--notify` is enabled
+- clean corpora do not send notifications
+- missing webhook environment variables produce an actionable exit `2`
+- Slack/generic payload formatting is valid enough for receiving endpoints
+- adversarial corpora still do not trigger findings or notifications
+
+Tests will use local HTTP servers rather than external services.
+
+## Documentation and Examples
+
+`docs/wiki/Observability.md` will document policy notification blocks, required
+environment variables, systemd deployment, manual runs, and local corpus
+validation. New example policies under `examples/log-policies/` will demonstrate
+Discord, Slack, and generic webhook targets without real secrets.
+
+## Adversarial Review
+
+The implementation review will check for secret leakage, notification spam,
+false positives from generated adversarial corpora, webhook failure handling,
+provider payload correctness, and whether any follow-up work should be filed as
+new GitHub issues.

--- a/docs/wiki/Observability.md
+++ b/docs/wiki/Observability.md
@@ -30,6 +30,7 @@ Prometheus and Loki will repopulate from live data. **None require backup.**
 | **Log inspection timer** | Every 15 minutes |
 | **Log inspection policies** | `/home/mms/config/logging/inspection/policies` |
 | **Latest inspection report** | `/home/mms/config/logging/inspection/latest-report.json` |
+| **Notification env file** | `/home/mms/config/logging/inspection/notifications.env` |
 | **Autodeploy group** | `interactive` (daily at 02:00) |
 
 ## Service Management
@@ -166,6 +167,94 @@ service uses that exit code so critical policy matches are visible through
 `systemctl --user status mms-log-inspect.service` and
 `journalctl --user -u mms-log-inspect.service`.
 
+### Notifications
+
+Policies can notify webhook-compatible services when findings are present.
+Notifications are disabled by default. Enable scheduled notifications in
+inventory or role defaults:
+
+```yaml
+logging_inspection_notifications_enabled: true
+```
+
+When enabled, the logging role creates
+`~/config/logging/inspection/notifications.env` with mode `0600` if it does not
+already exist. Add webhook URLs there using the environment-variable names from
+your policy files:
+
+```bash
+MMS_DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+MMS_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+MMS_GENERIC_WEBHOOK_URL=https://example.invalid/mms-alert-bridge
+```
+
+Do not commit real webhook URLs. Keep them in Ansible Vault or edit the
+deployed `notifications.env` on the host.
+
+Add a `notifications` array to any policy file:
+
+```json
+{
+  "name": "storage-pressure",
+  "description": "Detect log messages that indicate storage exhaustion.",
+  "window_minutes": 60,
+  "notifications": [
+    {
+      "id": "ops-discord",
+      "provider": "discord",
+      "webhook_url_env": "MMS_DISCORD_WEBHOOK_URL",
+      "min_severity": "warning"
+    }
+  ],
+  "rules": [
+    {
+      "id": "disk-full",
+      "severity": "critical",
+      "description": "A service reports that disk space is exhausted.",
+      "service": "*",
+      "patterns": ["no space left on device", "ENOSPC", "disk full"],
+      "threshold": 1
+    }
+  ]
+}
+```
+
+Supported providers are:
+
+| Provider | Payload |
+|----------|---------|
+| `discord` | `{"content": "..."}` |
+| `slack` | `{"text": "..."}` |
+| `generic` | Structured JSON with `summary`, `findings`, and `generated_at` |
+
+Use `generic` for automation bridges, including services that forward webhook
+payloads to WhatsApp.
+
+A complete example is available at
+`examples/log-notification-policies/notification-webhooks.json`. Copy it into
+`~/config/logging/inspection/policies/` only after setting the referenced
+environment variables.
+
+Run a notification-enabled inspection manually:
+
+```bash
+set -a
+source ~/config/logging/inspection/notifications.env
+set +a
+
+~/config/logging/bin/mms-log-inspect \
+  --loki-url http://localhost:3100 \
+  --lookback-minutes 60 \
+  --query-limit 5000 \
+  --policy ~/config/logging/inspection/policies \
+  --output-json ~/config/logging/inspection/latest-report.json \
+  --fail-on critical \
+  --notify
+```
+
+Notification failures exit `2` after writing the JSON report. Missing webhook
+environment variables are reported by variable name only.
+
 ### Testing Policies Locally
 
 Use `scripts/generate-test-corpus` to create deterministic JSONL logs, then run
@@ -189,6 +278,9 @@ python3 -m json.tool /tmp/mms-log-report.json
 Available scenarios are `clean`, `faulty`, and `adversarial`. Use `clean` to
 check false positives, `faulty` to confirm expected detections, and
 `adversarial` to review near-miss log lines that should not trigger policies.
+For notification tests, point policy `webhook_url_env` values at a local webhook
+receiver or a disposable test channel before using production destinations,
+then add `--notify` to the inspection command.
 
 ## Health Checks
 

--- a/examples/log-notification-policies/notification-webhooks.json
+++ b/examples/log-notification-policies/notification-webhooks.json
@@ -1,0 +1,35 @@
+{
+  "name": "notification-webhooks",
+  "description": "Example notification targets for policy findings.",
+  "window_minutes": 60,
+  "notifications": [
+    {
+      "id": "ops-discord",
+      "provider": "discord",
+      "webhook_url_env": "MMS_DISCORD_WEBHOOK_URL",
+      "min_severity": "warning"
+    },
+    {
+      "id": "ops-slack",
+      "provider": "slack",
+      "webhook_url_env": "MMS_SLACK_WEBHOOK_URL",
+      "min_severity": "critical"
+    },
+    {
+      "id": "automation-bridge",
+      "provider": "generic",
+      "webhook_url_env": "MMS_GENERIC_WEBHOOK_URL",
+      "min_severity": "critical"
+    }
+  ],
+  "rules": [
+    {
+      "id": "notifiable-storage-pressure",
+      "severity": "critical",
+      "description": "A service reports that disk space is exhausted.",
+      "service": "*",
+      "patterns": ["no space left on device", "ENOSPC", "disk full"],
+      "threshold": 1
+    }
+  ]
+}

--- a/roles/logging/defaults/main.yml
+++ b/roles/logging/defaults/main.yml
@@ -47,3 +47,5 @@ logging_inspection_query_limit: 5000
 logging_inspection_fail_on: critical
 logging_inspection_policy_dir: "{{ logging_config_dir }}/inspection/policies"
 logging_inspection_output_file: "{{ logging_config_dir }}/inspection/latest-report.json"
+logging_inspection_notifications_enabled: false
+logging_inspection_environment_file: "{{ logging_config_dir }}/inspection/notifications.env"

--- a/roles/logging/tasks/setup.yml
+++ b/roles/logging/tasks/setup.yml
@@ -90,6 +90,20 @@
     mode: "0644"
   become: true
 
+- name: Create log inspection notification environment file
+  ansible.builtin.copy:
+    dest: "{{ logging_inspection_environment_file }}"
+    owner: "{{ mms_user }}"
+    group: "{{ mms_user }}"
+    mode: "0600"
+    force: false
+    content: |
+      # Add webhook URLs referenced by policy notification targets.
+      # Example:
+      # MMS_DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+  become: true
+  when: logging_inspection_notifications_enabled | bool
+
 - name: Deploy log inspection service
   ansible.builtin.template:
     src: mms-log-inspect.service.j2

--- a/roles/logging/templates/mms-log-inspect.service.j2
+++ b/roles/logging/templates/mms-log-inspect.service.j2
@@ -6,4 +6,7 @@ After=loki.service
 
 [Service]
 Type=oneshot
-ExecStart={{ logging_config_dir }}/bin/mms-log-inspect --loki-url http://localhost:3100 --lookback-minutes {{ logging_inspection_lookback_minutes }} --query-limit {{ logging_inspection_query_limit }} --policy {{ logging_inspection_policy_dir }} --output-json {{ logging_inspection_output_file }} --fail-on {{ logging_inspection_fail_on }}
+{% if logging_inspection_notifications_enabled %}
+EnvironmentFile={{ logging_inspection_environment_file }}
+{% endif %}
+ExecStart={{ logging_config_dir }}/bin/mms-log-inspect --loki-url http://localhost:3100 --lookback-minutes {{ logging_inspection_lookback_minutes }} --query-limit {{ logging_inspection_query_limit }} --policy {{ logging_inspection_policy_dir }} --output-json {{ logging_inspection_output_file }} --fail-on {{ logging_inspection_fail_on }}{% if logging_inspection_notifications_enabled %} --notify{% endif %}

--- a/scripts/mms-log-inspect
+++ b/scripts/mms-log-inspect
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 import urllib.error
@@ -34,10 +35,19 @@ class Rule:
 
 
 @dataclass(frozen=True)
+class NotificationTarget:
+    id: str
+    provider: str
+    webhook_url_env: str
+    min_severity: str
+
+
+@dataclass(frozen=True)
 class Policy:
     name: str
     description: str
     window_minutes: int
+    notifications: tuple[NotificationTarget, ...]
     rules: tuple[Rule, ...]
 
 
@@ -64,6 +74,11 @@ def parse_args() -> argparse.Namespace:
         choices=tuple(SEVERITY_ORDER),
         default="critical",
         help="Exit 1 when findings at this severity or above exist.",
+    )
+    parser.add_argument(
+        "--notify",
+        action="store_true",
+        help="Send policy-defined webhook notifications for matching findings.",
     )
     return parser.parse_args()
 
@@ -119,6 +134,40 @@ def load_rule(raw_rule: object, index: int) -> Rule:
     )
 
 
+def load_notification(raw_notification: object, index: int) -> NotificationTarget:
+    notification = require_mapping(raw_notification, f"notifications[{index}]")
+    notification_id = require_string(notification, "id", f"notifications[{index}]")
+    context = f"notification {notification_id}"
+    provider = require_string(notification, "provider", context)
+    if provider not in {"discord", "slack", "generic"}:
+        raise PolicyError(f"Invalid policy: {context} has unsupported provider {provider}")
+
+    min_severity = require_string(notification, "min_severity", context)
+    if min_severity not in SEVERITY_ORDER:
+        raise PolicyError(
+            f"Invalid policy: {context} has unsupported min_severity {min_severity}"
+        )
+
+    return NotificationTarget(
+        id=notification_id,
+        provider=provider,
+        webhook_url_env=require_string(notification, "webhook_url_env", context),
+        min_severity=min_severity,
+    )
+
+
+def load_notifications(policy: dict[str, Any]) -> tuple[NotificationTarget, ...]:
+    raw_notifications = policy.get("notifications", [])
+    if raw_notifications is None:
+        return ()
+    if not isinstance(raw_notifications, list):
+        raise PolicyError("Invalid policy: notifications must be a list")
+    return tuple(
+        load_notification(notification, index)
+        for index, notification in enumerate(raw_notifications)
+    )
+
+
 def load_policy(path: Path) -> Policy:
     try:
         raw_policy = json.loads(path.read_text(encoding="utf-8"))
@@ -134,6 +183,7 @@ def load_policy(path: Path) -> Policy:
         name=require_string(policy, "name", str(path)),
         description=require_string(policy, "description", str(path)),
         window_minutes=require_positive_int(policy, "window_minutes", str(path)),
+        notifications=load_notifications(policy),
         rules=tuple(load_rule(rule, index) for index, rule in enumerate(raw_rules)),
     )
 
@@ -287,12 +337,15 @@ def summarize(findings: Iterable[dict[str, Any]]) -> dict[str, int]:
     return summary
 
 
-def write_report(path: Path, findings: list[dict[str, Any]]) -> None:
-    report = {
+def build_report(findings: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
         "generated_at": datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z"),
         "summary": summarize(findings),
         "findings": findings,
     }
+
+
+def write_report(path: Path, report: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
 
@@ -300,6 +353,91 @@ def write_report(path: Path, findings: list[dict[str, Any]]) -> None:
 def has_failure(findings: Iterable[dict[str, Any]], fail_on: str) -> bool:
     minimum = SEVERITY_ORDER[fail_on]
     return any(SEVERITY_ORDER[str(finding["severity"])] >= minimum for finding in findings)
+
+
+def filtered_findings(
+    findings: Iterable[dict[str, Any]],
+    min_severity: str,
+) -> list[dict[str, Any]]:
+    minimum = SEVERITY_ORDER[min_severity]
+    return [
+        finding
+        for finding in findings
+        if SEVERITY_ORDER[str(finding["severity"])] >= minimum
+    ]
+
+
+def notification_text(target: NotificationTarget, findings: list[dict[str, Any]]) -> str:
+    count = len(findings)
+    noun = "issue" if count == 1 else "issues"
+    rule_ids = ", ".join(str(finding["rule_id"]) for finding in findings[:5])
+    suffix = "" if len(findings) <= 5 else f", +{len(findings) - 5} more"
+    return (
+        f"MMS log inspection found {count} {noun} at or above "
+        f"{target.min_severity}: {rule_ids}{suffix}"
+    )
+
+
+def notification_payload(
+    target: NotificationTarget,
+    report: dict[str, Any],
+    findings: list[dict[str, Any]],
+) -> dict[str, Any]:
+    if target.provider == "generic":
+        return {
+            "notification_id": target.id,
+            "summary": report["summary"],
+            "findings": findings,
+            "generated_at": report["generated_at"],
+        }
+
+    text = notification_text(target, findings)
+    if target.provider == "discord":
+        return {"content": text}
+    if target.provider == "slack":
+        return {"text": text}
+    raise PolicyError(f"Invalid policy: unsupported provider {target.provider}")
+
+
+def send_webhook(target: NotificationTarget, payload: dict[str, Any]) -> None:
+    webhook_url = os.environ.get(target.webhook_url_env, "")
+    if not webhook_url:
+        raise ValueError(
+            f"Notification {target.id} requires environment variable "
+            f"{target.webhook_url_env}"
+        )
+
+    body = json.dumps(payload).encode()
+    request = urllib.request.Request(
+        webhook_url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            if response.status >= 400:
+                raise ValueError(
+                    f"Notification {target.id} failed with HTTP {response.status}"
+                )
+    except urllib.error.HTTPError as error:
+        raise ValueError(
+            f"Notification {target.id} failed with HTTP {error.code}"
+        ) from error
+    except urllib.error.URLError as error:
+        raise ValueError(f"Notification {target.id} failed: {error.reason}") from error
+
+
+def notify_findings(policies: Iterable[Policy], report: dict[str, Any]) -> None:
+    findings = report["findings"]
+    for policy in policies:
+        policy_findings = [
+            finding for finding in findings if finding["policy"] == policy.name
+        ]
+        for target in policy.notifications:
+            matches = filtered_findings(policy_findings, target.min_severity)
+            if matches:
+                send_webhook(target, notification_payload(target, report, matches))
 
 
 def main() -> int:
@@ -319,7 +457,14 @@ def main() -> int:
         print(error, file=sys.stderr)
         return 2
 
-    write_report(args.output_json, findings)
+    report = build_report(findings)
+    write_report(args.output_json, report)
+    if args.notify:
+        try:
+            notify_findings(policies, report)
+        except (OSError, PolicyError, ValueError) as error:
+            print(error, file=sys.stderr)
+            return 2
     return 1 if has_failure(findings, args.fail_on) else 0
 
 

--- a/tests/logging/test_log_inspection.py
+++ b/tests/logging/test_log_inspection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -14,11 +15,15 @@ GENERATE_CORPUS = REPO_ROOT / "scripts" / "generate-test-corpus"
 INSPECT_LOGS = REPO_ROOT / "scripts" / "mms-log-inspect"
 
 
-def run_command(*args: str) -> subprocess.CompletedProcess[str]:
+def run_command(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    command_env = os.environ.copy()
+    if env:
+        command_env.update(env)
     return subprocess.run(
         [sys.executable, *args],
         cwd=REPO_ROOT,
         check=False,
+        env=command_env,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -55,6 +60,33 @@ def write_policy(path: Path) -> None:
                 "patterns": ["\\berror\\b", "exception", "fatal"],
                 "threshold": 2,
             },
+        ],
+    }
+    path.write_text(json.dumps(policy), encoding="utf-8")
+
+
+def write_notification_policy(path: Path, provider: str = "discord") -> None:
+    policy = {
+        "name": "functional-notification-policy",
+        "description": "Detect common failures and notify operators.",
+        "window_minutes": 60,
+        "notifications": [
+            {
+                "id": f"ops-{provider}",
+                "provider": provider,
+                "webhook_url_env": "MMS_TEST_WEBHOOK_URL",
+                "min_severity": "warning",
+            }
+        ],
+        "rules": [
+            {
+                "id": "storage-full",
+                "severity": "critical",
+                "description": "Storage exhaustion blocks writes.",
+                "service": "*",
+                "patterns": ["no space left on device", "ENOSPC"],
+                "threshold": 1,
+            }
         ],
     }
     path.write_text(json.dumps(policy), encoding="utf-8")
@@ -101,12 +133,40 @@ class LokiHandler(BaseHTTPRequestHandler):
         return
 
 
+class WebhookHandler(BaseHTTPRequestHandler):
+    requests: list[dict[str, object]] = []
+
+    def do_POST(self) -> None:  # noqa: N802
+        body = self.rfile.read(int(self.headers["Content-Length"]))
+        WebhookHandler.requests.append(
+            {
+                "path": self.path,
+                "content_type": self.headers.get("Content-Type"),
+                "payload": json.loads(body.decode()),
+            }
+        )
+        self.send_response(204)
+        self.end_headers()
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
 def loki_server() -> tuple[ThreadingHTTPServer, str]:
     server = ThreadingHTTPServer(("127.0.0.1", 0), LokiHandler)
     thread = Thread(target=server.serve_forever, daemon=True)
     thread.start()
     host, port = server.server_address
     return server, f"http://{host}:{port}"
+
+
+def webhook_server() -> tuple[ThreadingHTTPServer, str]:
+    WebhookHandler.requests = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), WebhookHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    return server, f"http://{host}:{port}/webhook"
 
 
 def test_clean_corpus_has_no_findings(tmp_path: Path) -> None:
@@ -291,3 +351,154 @@ def test_loki_mode_evaluates_query_range_results(tmp_path: Path) -> None:
     finding_ids = {finding["rule_id"] for finding in result["findings"]}
     assert finding_ids == {"application-error", "storage-full"}
     assert LokiHandler.requested_query == '{job="mms"}'
+
+
+def test_faulty_corpus_sends_discord_notification_when_enabled(tmp_path: Path) -> None:
+    corpus = tmp_path / "faulty.jsonl"
+    policy = tmp_path / "policy.json"
+    report = tmp_path / "report.json"
+    write_notification_policy(policy)
+    server, webhook_url = webhook_server()
+
+    generated = run_command(
+        str(GENERATE_CORPUS),
+        "--scenario",
+        "faulty",
+        "--entries",
+        "40",
+        "--output",
+        str(corpus),
+    )
+    assert generated.returncode == 0, generated.stderr
+
+    try:
+        inspected = run_command(
+            str(INSPECT_LOGS),
+            "--input-jsonl",
+            str(corpus),
+            "--policy",
+            str(policy),
+            "--output-json",
+            str(report),
+            "--fail-on",
+            "critical",
+            "--notify",
+            env={"MMS_TEST_WEBHOOK_URL": webhook_url},
+        )
+    finally:
+        server.shutdown()
+
+    assert inspected.returncode == 1, inspected.stderr
+    assert len(WebhookHandler.requests) == 1
+    payload = WebhookHandler.requests[0]["payload"]
+    assert payload["content"].startswith("MMS log inspection found 1 issue")
+    assert "storage-full" in payload["content"]
+
+
+def test_clean_corpus_does_not_send_notification(tmp_path: Path) -> None:
+    corpus = tmp_path / "clean.jsonl"
+    policy = tmp_path / "policy.json"
+    report = tmp_path / "report.json"
+    write_notification_policy(policy)
+    server, webhook_url = webhook_server()
+
+    generated = run_command(
+        str(GENERATE_CORPUS),
+        "--scenario",
+        "clean",
+        "--entries",
+        "24",
+        "--output",
+        str(corpus),
+    )
+    assert generated.returncode == 0, generated.stderr
+
+    try:
+        inspected = run_command(
+            str(INSPECT_LOGS),
+            "--input-jsonl",
+            str(corpus),
+            "--policy",
+            str(policy),
+            "--output-json",
+            str(report),
+            "--notify",
+            env={"MMS_TEST_WEBHOOK_URL": webhook_url},
+        )
+    finally:
+        server.shutdown()
+
+    assert inspected.returncode == 0, inspected.stderr
+    assert WebhookHandler.requests == []
+
+
+def test_missing_notification_webhook_env_returns_actionable_error(tmp_path: Path) -> None:
+    corpus = tmp_path / "faulty.jsonl"
+    policy = tmp_path / "policy.json"
+    report = tmp_path / "report.json"
+    write_notification_policy(policy)
+
+    generated = run_command(
+        str(GENERATE_CORPUS),
+        "--scenario",
+        "faulty",
+        "--entries",
+        "40",
+        "--output",
+        str(corpus),
+    )
+    assert generated.returncode == 0, generated.stderr
+
+    inspected = run_command(
+        str(INSPECT_LOGS),
+        "--input-jsonl",
+        str(corpus),
+        "--policy",
+        str(policy),
+        "--output-json",
+        str(report),
+        "--notify",
+        env={"MMS_TEST_WEBHOOK_URL": ""},
+    )
+
+    assert inspected.returncode == 2
+    assert "MMS_TEST_WEBHOOK_URL" in inspected.stderr
+
+
+def test_generic_notification_sends_structured_report(tmp_path: Path) -> None:
+    corpus = tmp_path / "faulty.jsonl"
+    policy = tmp_path / "policy.json"
+    report = tmp_path / "report.json"
+    write_notification_policy(policy, provider="generic")
+    server, webhook_url = webhook_server()
+
+    generated = run_command(
+        str(GENERATE_CORPUS),
+        "--scenario",
+        "faulty",
+        "--entries",
+        "40",
+        "--output",
+        str(corpus),
+    )
+    assert generated.returncode == 0, generated.stderr
+
+    try:
+        inspected = run_command(
+            str(INSPECT_LOGS),
+            "--input-jsonl",
+            str(corpus),
+            "--policy",
+            str(policy),
+            "--output-json",
+            str(report),
+            "--notify",
+            env={"MMS_TEST_WEBHOOK_URL": webhook_url},
+        )
+    finally:
+        server.shutdown()
+
+    assert inspected.returncode == 1, inspected.stderr
+    payload = WebhookHandler.requests[0]["payload"]
+    assert payload["summary"] == {"critical": 1, "warning": 0, "info": 0}
+    assert payload["findings"][0]["rule_id"] == "storage-full"

--- a/tests/logging/test_log_inspection.py
+++ b/tests/logging/test_log_inspection.py
@@ -502,3 +502,42 @@ def test_generic_notification_sends_structured_report(tmp_path: Path) -> None:
     payload = WebhookHandler.requests[0]["payload"]
     assert payload["summary"] == {"critical": 1, "warning": 0, "info": 0}
     assert payload["findings"][0]["rule_id"] == "storage-full"
+
+
+def test_slack_notification_sends_text_payload(tmp_path: Path) -> None:
+    corpus = tmp_path / "faulty.jsonl"
+    policy = tmp_path / "policy.json"
+    report = tmp_path / "report.json"
+    write_notification_policy(policy, provider="slack")
+    server, webhook_url = webhook_server()
+
+    generated = run_command(
+        str(GENERATE_CORPUS),
+        "--scenario",
+        "faulty",
+        "--entries",
+        "40",
+        "--output",
+        str(corpus),
+    )
+    assert generated.returncode == 0, generated.stderr
+
+    try:
+        inspected = run_command(
+            str(INSPECT_LOGS),
+            "--input-jsonl",
+            str(corpus),
+            "--policy",
+            str(policy),
+            "--output-json",
+            str(report),
+            "--notify",
+            env={"MMS_TEST_WEBHOOK_URL": webhook_url},
+        )
+    finally:
+        server.shutdown()
+
+    assert inspected.returncode == 1, inspected.stderr
+    payload = WebhookHandler.requests[0]["payload"]
+    assert payload["text"].startswith("MMS log inspection found 1 issue")
+    assert "storage-full" in payload["text"]

--- a/tests/logging/test_logging_role_notifications.py
+++ b/tests/logging/test_logging_role_notifications.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def read_repo_file(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_notification_defaults_are_disabled_and_use_private_env_file() -> None:
+    defaults = read_repo_file("roles/logging/defaults/main.yml")
+
+    assert "logging_inspection_notifications_enabled: false" in defaults
+    assert "logging_inspection_environment_file:" in defaults
+    assert "notifications.env" in defaults
+
+
+def test_log_inspection_service_enables_notifications_conditionally() -> None:
+    service = read_repo_file("roles/logging/templates/mms-log-inspect.service.j2")
+
+    assert "{% if logging_inspection_notifications_enabled %}" in service
+    assert "EnvironmentFile={{ logging_inspection_environment_file }}" in service
+    assert "--notify" in service
+
+
+def test_notification_environment_file_is_private_and_operator_owned() -> None:
+    setup = read_repo_file("roles/logging/tasks/setup.yml")
+
+    assert "Create log inspection notification environment file" in setup
+    assert "mode: \"0600\"" in setup
+    assert "force: false" in setup


### PR DESCRIPTION
## Summary

- Adds policy-defined webhook notifications to `mms-log-inspect` behind `--notify`, with Discord, Slack, and generic webhook payloads.
- Keeps webhook secrets in environment variables and wires scheduled runs through an optional private `notifications.env` file.
- Adds generated-corpus functional tests, notification role tests, user docs, a non-deployed example notification policy, and adversarial review notes.

Closes #88.

## Verification

- `.venv/bin/python -m pytest -q tests/logging/test_log_inspection.py tests/logging/test_logging_role_notifications.py` -> 13 passed
- `make lint` -> 0 failures, 0 warnings
- `source .venv/bin/activate && ansible-playbook playbooks/deploy-service.yml -e service_name=logging --syntax-check` -> syntax check passed
- `scripts/generate-test-corpus --scenario faulty --entries 40 ...` followed by `scripts/mms-log-inspect --input-jsonl ... --policy examples/log-policies ... --fail-on critical` -> exited 1 as expected and produced valid JSON

## Adversarial Review

Plan and code review notes are recorded in `docs/superpowers/reviews/2026-05-10-notification-support-issue-88.md`.

Review findings addressed in this branch:

- Webhook URLs are supplied through environment variables only and are not printed in errors.
- Scheduled notification delivery is disabled by default.
- The notification environment file is mode `0600` and is not overwritten on redeploy.
- Notification examples live outside the active policy directory that Ansible deploys.
- Clean and adversarial generated corpora do not send notifications.

## Deferred Work

None. No follow-up issues were filed.
