### PR TITLE
feat(profilarr): add Profilarr v2 and refactor restore dispatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Max Media Stack (MMS)** — Ansible project to provision and manage a full homelab media stack on a Fedora VM (Proxmox 9.x), using rootless Podman with Quadlet systemd integration.
 
-**Services:** Prowlarr, Radarr, Radarr 4K, Sonarr, Lidarr, SABnzbd, Jellyfin, Plex, Tautulli, Kometa, Immich, Channels DVR, Navidrome, Open Notebook, Grafana, Prometheus
+**Services:** Prowlarr, Profilarr, Radarr, Radarr 4K, Sonarr, Lidarr, SABnzbd, Jellyfin, Plex, Tautulli, Kometa, Immich, Channels DVR, Navidrome, Open Notebook, Grafana, Prometheus
 **Storage:** TrueNAS NFS exports mounted at `/data`
 **Access:** Traefik reverse proxy on port 80, Tailscale only (no LAN exposure)
 
@@ -75,6 +75,7 @@ ansible-playbook playbooks/migrate.yml -e source_host=lxc-hostname
 - Inter-container `host_whitelist` must include the bare container hostname (e.g., `sabnzbd`) in addition to the Traefik subdomain FQDN
 - Plex backup type (`backup_type: "plex"`) stops the service and excludes regenerable directories (Cache, Crash Reports, Updates, Codecs) — similar pattern to Jellyfin's cache exclusion
 - Backup role uses `backup_*` prefix for all variables; API backup variables use `backup_api_*`
+- Restore dispatch is data-driven: both `mms-restore.sh` and `playbooks/restore.yml` read `backup_type` from each `services/<name>.yml` (and from `mms_special_services` for traefik/immich/open-notebook) to route to the matching `restore_<type>` function (bash) or `playbooks/tasks/restore/restore-<type>.yml` (Ansible) — adding a new service only requires declaring `backup_type` once
 - Logging role uses `logging_*` prefix for all defaults; Grafana state and Prometheus TSDB are fully provisioned/retention-managed and disposable (no backup needed); `podman-exporter` requires `podman.socket` enabled for the mms user
 - Multi-container role testability: roles like `open_notebook` split into `setup.yml` (files/templates, testable without Podman) and `containers.yml` (runtime: image pull, start, healthcheck); Molecule tests target `setup.yml` only
 - Molecule shared pre-tasks: `molecule/shared/prepare_mms_user.yml` creates the mms user/group/quadlet directory; all role converge playbooks include it via `include_tasks`

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Ansible project to provision and manage a full homelab media stack on a Fedora V
 | Service   | URL                              | Description                    |
 |-----------|----------------------------------|--------------------------------|
 | Prowlarr  | `prowlarr.media.example.com`     | Indexer manager                |
+| Profilarr | `profilarr.media.example.com`    | Quality profile & custom format manager |
 | Radarr    | `radarr.media.example.com`       | Movie automation               |
 | Radarr 4K | `radarr4k.media.example.com`     | 4K movie automation            |
 | Sonarr    | `sonarr.media.example.com`       | TV show automation             |
@@ -34,8 +35,8 @@ Ansible project to provision and manage a full homelab media stack on a Fedora V
 │  │  │                                              │  │  │
 │  │  │  traefik (:80) ─── Host header routing       │  │  │
 │  │  │      │                                       │  │  │
-│  │  │      ├── prowlarr  radarr  radarr4k          │  │  │
-│  │  │      ├── sonarr  lidarr  sabnzbd             │  │  │
+│  │  │      ├── prowlarr  profilarr  radarr         │  │  │
+│  │  │      ├── radarr4k  sonarr  lidarr  sabnzbd   │  │  │
 │  │  │      ├── jellyfin  plex  channels            │  │  │
 │  │  │      ├── tautulli  kometa  navidrome         │  │  │
 │  │  │      ├── open-notebook  open-notebook-db     │  │  │

--- a/docs/wiki/Adding-a-New-Service.md
+++ b/docs/wiki/Adding-a-New-Service.md
@@ -69,3 +69,15 @@ ansible-playbook playbooks/deploy-service.yml -e service_name=myservice
 ## Multi-container services
 
 The data-driven `quadlet_service` pattern works for single-container services. Multi-container services like Immich (server, ML, PostgreSQL, Redis) and Open Notebook (app, SurrealDB) need their own dedicated role under `roles/` with explicit Quadlet templates for each container and handler-based service ordering.
+
+## Backup and restore
+
+Declare `backup_type` in the service file. Both `mms-backup.sh` and `mms-restore.sh` dispatch on this value, as does `playbooks/restore.yml`. Currently understood values:
+
+- `arr` — generic stop/tar/start. Use for any *arr-family service or anything with a single config directory.
+- `sabnzbd` — extracts into the service's own subdirectory.
+- `jellyfin` / `plex` — bash restore preserves the cache directory.
+- `immich` — multi-container; backup includes a PostgreSQL dump.
+- `open-notebook` — cold backup of both the app and SurrealDB directories.
+
+Adding a new value requires adding the corresponding restore function in `roles/backup/templates/mms-restore.sh.j2` (bash side) and a `playbooks/tasks/restore/restore-<type>.yml` (playbook side). Existing values just work; e.g. `backup_type: arr` for a new *arr-family service needs no additional code.

--- a/docs/wiki/Backup-and-Restore.md
+++ b/docs/wiki/Backup-and-Restore.md
@@ -67,6 +67,8 @@ ansible-playbook playbooks/restore.yml \
 
 Multi-container services like Open Notebook use the same restore command -- the playbook handles stopping/starting both containers and restoring both directories from the single archive automatically.
 
+The restore playbook and the `mms-restore.sh` script both dispatch from each service's `backup_type` (declared in `services/<name>.yml`) plus the `mms_special_services` registry in `inventory/group_vars/mms/vars.yml` (covering traefik, immich, and open-notebook). Adding a new *arr-family service is therefore zero-touch on the restore side -- it picks up `restore_arr` automatically once `backup_type: arr` is set.
+
 ## Backup encryption with age
 
 MMS encrypts config backups using `age`, a simple file encryption tool. Encryption uses a public key (safe to store in config); decryption requires the corresponding private key (identity file), which should be kept offline or in a secure location -- never on the backup server itself.

--- a/docs/wiki/Profilarr.md
+++ b/docs/wiki/Profilarr.md
@@ -1,0 +1,59 @@
+# Profilarr
+
+Quality Profile and Custom Format manager for Radarr/Sonarr/Lidarr. Profilarr v2 syncs curated profiles (TRaSH-style) and custom formats into the *arr applications.
+
+| Property | Value |
+|----------|-------|
+| **Image** | `ghcr.io/dictionarry-hub/profilarr` |
+| **Container name** | `profilarr` |
+| **Internal port** | 6868 |
+| **Traefik subdomain** | `profilarr.media.drc.nz` |
+| **Config directory** | `/home/mms/config/profilarr` |
+| **Health endpoint** | `http://localhost:6868/api/v1/health` |
+| **Backup type** | `arr` (config backup) |
+| **Autodeploy group** | `backend` (every 30 min) |
+
+## Service Management
+
+```bash
+systemctl --user start profilarr.service
+systemctl --user stop profilarr.service
+systemctl --user restart profilarr.service
+systemctl --user status profilarr.service
+```
+
+## Viewing Logs
+
+```bash
+journalctl --user -u profilarr --since today
+journalctl --user -u profilarr -f
+
+podman logs --tail 50 profilarr
+podman logs -f profilarr
+```
+
+## Health Check
+
+```bash
+podman healthcheck run profilarr
+podman exec profilarr curl -sf http://localhost:6868/api/v1/health
+curl -sf http://profilarr.media.drc.nz/api/v1/health
+```
+
+## Backup & Restore
+
+Profilarr uses the generic `arr` backup type -- daily encrypted tar of `/home/mms/config/profilarr/`.
+
+```bash
+# Restore from config backup
+ansible-playbook playbooks/restore.yml \
+  -e service_name=profilarr \
+  -e backup_file=/data/backups/config/profilarr/<backup-file>.tar.zst.age \
+  -e backup_age_identity_file=/path/to/age-identity.txt
+```
+
+## Notes
+
+- Profilarr v2 introduced breaking changes from v1 (new GHCR image, new env contract). The MMS image is pinned to a v2 tag and managed by Renovate.
+- The optional `parser` sidecar (for custom-format and quality-profile testing) is intentionally not deployed. Add a separate service definition if you need it.
+- Profilarr runs with `PUID=0`/`PGID=0` (container root) following the LSIO pattern used by every other *arr service in MMS. Under rootless Podman with `UserNS=host`, container UID 0 maps to host UID 3000 (the `mms` user), so files in `/home/mms/config/profilarr/` are owned by `mms:mms` on the host.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -12,6 +12,7 @@
 
 **Services**
 - [Prowlarr](Prowlarr)
+- [Profilarr](Profilarr)
 - [Radarr](Radarr)
 - [Radarr 4K](Radarr-4K)
 - [Sonarr](Sonarr)

--- a/inventory/group_vars/mms/vars.yml
+++ b/inventory/group_vars/mms/vars.yml
@@ -27,6 +27,7 @@ mms_nfs_mounts:
 # Services to deploy (matches filenames in services/)
 mms_services:
   - prowlarr
+  - profilarr
   - radarr
   - radarr4k
   - sonarr
@@ -39,12 +40,28 @@ mms_services:
   - channels
   - navidrome
 
+# Special services that aren't in services/*.yml but participate in backup/restore.
+# These are deployed by their own roles (immich, open_notebook) or by traefik role,
+# not by quadlet_service. Listing them here so the restore dispatcher knows their
+# backup_type without forcing them into the services/ schema.
+mms_special_services:
+  - name: traefik
+    backup_type: arr
+  - name: immich
+    backup_type: immich
+  - name: open-notebook
+    backup_type: open-notebook
+
 # Traefik reverse proxy (mms_traefik_domain is in group_vars/all)
 mms_traefik_routes:
   prowlarr:
     subdomain: prowlarr
     container: prowlarr
     port: 9696
+  profilarr:
+    subdomain: profilarr
+    container: profilarr
+    port: 6868
   radarr:
     subdomain: radarr
     container: radarr
@@ -107,6 +124,7 @@ autodeploy_groups:
     schedule: "*-*-* *:00/30:00"
     services:
       - prowlarr
+      - profilarr
       - radarr
       - radarr4k
       - sonarr

--- a/playbooks/restore.yml
+++ b/playbooks/restore.yml
@@ -31,95 +31,50 @@
         fail_msg: "backup_age_identity_file is required for encrypted backups. Use -e backup_age_identity_file=/path/to/key"
       when: backup_file is match('.*\\.age$')
 
+    # Resolve backup_type so the dispatcher below can route to the right
+    # per-type task file. Look in services/<name>.yml first; fall back to
+    # the mms_special_services registry (traefik / immich / open-notebook).
+    - name: Load service definition for restore dispatch  # noqa: no-relative-paths
+      ansible.builtin.include_vars:
+        file: "{{ playbook_dir }}/../services/{{ service_name }}.yml"
+        name: _service_def
+      when: service_name in mms_services
+
+    - name: Set backup_type from service definition
+      ansible.builtin.set_fact:
+        _restore_backup_type: "{{ _service_def[service_name].backup_type }}"
+      when: service_name in mms_services
+
+    - name: Set backup_type from mms_special_services
+      ansible.builtin.set_fact:
+        _restore_backup_type: >-
+          {{ (mms_special_services | selectattr('name', 'equalto', service_name) | first).backup_type }}
+      when:
+        - service_name not in mms_services
+        - service_name in (mms_special_services | map(attribute='name') | list)
+
+    - name: Assert service is known to MMS
+      ansible.builtin.assert:
+        that:
+          - _restore_backup_type is defined
+          - _restore_backup_type | length > 0
+        fail_msg: >-
+          Service '{{ service_name }}' is not declared in mms_services or
+          mms_special_services. Add it to the inventory before restoring.
+
+    - name: Assert backup_type has a known restore handler
+      ansible.builtin.assert:
+        that:
+          - _restore_backup_type in ['arr', 'sabnzbd', 'jellyfin', 'plex', 'immich', 'open-notebook']
+        fail_msg: >-
+          backup_type '{{ _restore_backup_type }}' for service '{{ service_name }}'
+          has no restore handler. Supported types: arr, sabnzbd, jellyfin, plex,
+          immich, open-notebook. Either change backup_type in services/{{ service_name }}.yml
+          or add playbooks/tasks/restore/restore-{{ _restore_backup_type }}.yml.
+
   tasks:
-    - name: Restore standard service  # noqa: no-relative-paths
-      ansible.builtin.include_tasks:
-        file: "{{ playbook_dir }}/../roles/backup/tasks/restore_service.yml"
-      vars:
-        _restore_label: "{{ service_name }}"
-        _restore_tmp_ext: tar.zst
-        _restore_service: "{{ service_name }}"
-        _restore_cmd: "zstd -d {{ backup_restore_file }} --stdout | tar -xf - -C {{ mms_config_dir }}"
-      when: service_name in ['prowlarr', 'radarr', 'radarr4k', 'sonarr', 'lidarr', 'jellyfin']
-
-    - name: Restore sabnzbd  # noqa: no-relative-paths
-      ansible.builtin.include_tasks:
-        file: "{{ playbook_dir }}/../roles/backup/tasks/restore_service.yml"
-      vars:
-        _restore_label: sabnzbd
-        _restore_tmp_ext: tar.zst
-        _restore_service: sabnzbd
-        _restore_cmd: "zstd -d {{ backup_restore_file }} --stdout | tar -xf - -C {{ mms_config_dir }}/sabnzbd"
-      when: service_name == 'sabnzbd'
-
-    - name: Restore immich database  # noqa: no-relative-paths
-      ansible.builtin.include_tasks:
-        file: "{{ playbook_dir }}/../roles/backup/tasks/restore_service.yml"
-      vars:
-        _restore_label: immich-db
-        _restore_tmp_ext: sql.zst
-        _restore_service: ""
-        _restore_cmd: >-
-          zstd -d {{ backup_restore_file }} --stdout |
-          podman exec -i immich-postgres psql -U postgres
-      when: service_name == 'immich' and 'db' in backup_file
-
-    - name: Restore immich config  # noqa: no-relative-paths
-      ansible.builtin.include_tasks:
-        file: "{{ playbook_dir }}/../roles/backup/tasks/restore_service.yml"
-      vars:
-        _restore_label: immich-config
-        _restore_tmp_ext: tar.zst
-        _restore_service: ""
-        _restore_cmd: "zstd -d {{ backup_restore_file }} --stdout | tar -xf - -C {{ mms_config_dir }}"
-      when: service_name == 'immich' and 'config' in backup_file
-
-    - name: Stop open-notebook services before restore
-      ansible.builtin.systemd:
-        name: "{{ item }}"
-        state: stopped
-        scope: user
-      environment: "{{ mms_systemd_env }}"
-      loop:
-        - open-notebook
-        - open-notebook-db
-      when: service_name == 'open-notebook'
-      failed_when: false
-
-    - name: Restore open-notebook  # noqa: no-relative-paths
-      ansible.builtin.include_tasks:
-        file: "{{ playbook_dir }}/../roles/backup/tasks/restore_service.yml"
-      vars:
-        _restore_label: open-notebook
-        _restore_tmp_ext: tar.zst
-        _restore_service: ""
-        _restore_cmd: "zstd -d {{ backup_restore_file }} --stdout | tar -xf - -C {{ mms_config_dir }}"
-      when: service_name == 'open-notebook'
-
-    - name: Fix ownership after open-notebook restore
-      ansible.builtin.file:
-        path: "{{ mms_config_dir }}/{{ item }}"
-        state: directory
-        owner: "{{ mms_user }}"
-        group: "{{ mms_user }}"
-        recurse: true
-      become: true
-      become_user: root
-      loop:
-        - open-notebook
-        - open-notebook-db
-      when: service_name == 'open-notebook'
-
-    - name: Start open-notebook services after restore
-      ansible.builtin.systemd:
-        name: "{{ item }}"
-        state: started
-        scope: user
-      environment: "{{ mms_systemd_env }}"
-      loop:
-        - open-notebook-db
-        - open-notebook
-      when: service_name == 'open-notebook'
+    - name: "Dispatch restore via backup_type {{ _restore_backup_type }}"
+      ansible.builtin.include_tasks: "tasks/restore/restore-{{ _restore_backup_type }}.yml"
 
     - name: Fix ownership after restore
       ansible.builtin.file:

--- a/playbooks/tasks/restore/restore-arr.yml
+++ b/playbooks/tasks/restore/restore-arr.yml
@@ -1,0 +1,11 @@
+---
+# Generic "stop, extract tar to config dir, start" restore.
+# Used for backup_type=arr services (prowlarr, profilarr, *arr, tautulli, kometa, traefik).
+- name: "Restore standard service ({{ service_name }})"  # noqa: no-relative-paths
+  ansible.builtin.include_tasks:
+    file: "{{ playbook_dir }}/../roles/backup/tasks/restore_service.yml"
+  vars:
+    _restore_label: "{{ service_name }}"
+    _restore_tmp_ext: tar.zst
+    _restore_service: "{{ service_name }}"
+    _restore_cmd: "zstd -d {{ backup_restore_file }} --stdout | tar -xf - -C {{ mms_config_dir }}"

--- a/playbooks/tasks/restore/restore-immich.yml
+++ b/playbooks/tasks/restore/restore-immich.yml
@@ -1,0 +1,24 @@
+---
+# Immich restore: branches on the backup filename. A file containing
+# "db" restores the PostgreSQL dump; otherwise restore the config tar.
+- name: "Restore immich database"  # noqa: no-relative-paths
+  ansible.builtin.include_tasks:
+    file: "{{ playbook_dir }}/../roles/backup/tasks/restore_service.yml"
+  vars:
+    _restore_label: immich-db
+    _restore_tmp_ext: sql.zst
+    _restore_service: ""
+    _restore_cmd: >-
+      zstd -d {{ backup_restore_file }} --stdout |
+      podman exec -i immich-postgres psql -U postgres
+  when: "'db' in backup_file"
+
+- name: "Restore immich config"  # noqa: no-relative-paths
+  ansible.builtin.include_tasks:
+    file: "{{ playbook_dir }}/../roles/backup/tasks/restore_service.yml"
+  vars:
+    _restore_label: immich-config
+    _restore_tmp_ext: tar.zst
+    _restore_service: ""
+    _restore_cmd: "zstd -d {{ backup_restore_file }} --stdout | tar -xf - -C {{ mms_config_dir }}"
+  when: "'db' not in backup_file"

--- a/playbooks/tasks/restore/restore-jellyfin.yml
+++ b/playbooks/tasks/restore/restore-jellyfin.yml
@@ -1,0 +1,5 @@
+---
+# Jellyfin restore. The current playbook treats jellyfin as arr-style
+# (the bash mms-restore.sh additionally preserves the cache directory).
+- name: "Dispatch jellyfin restore via arr-style extract"  # noqa: no-relative-paths
+  ansible.builtin.include_tasks: restore-arr.yml

--- a/playbooks/tasks/restore/restore-open-notebook.yml
+++ b/playbooks/tasks/restore/restore-open-notebook.yml
@@ -1,0 +1,46 @@
+---
+# Open Notebook restore: cold restore of both the app and the SurrealDB
+# container directories. Stop both, extract, fix ownership on both dirs,
+# then start db first followed by the app.
+- name: Stop open-notebook services before restore
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: stopped
+    scope: user
+  environment: "{{ mms_systemd_env }}"
+  loop:
+    - open-notebook
+    - open-notebook-db
+  failed_when: false
+
+- name: "Restore open-notebook"  # noqa: no-relative-paths
+  ansible.builtin.include_tasks:
+    file: "{{ playbook_dir }}/../roles/backup/tasks/restore_service.yml"
+  vars:
+    _restore_label: open-notebook
+    _restore_tmp_ext: tar.zst
+    _restore_service: ""
+    _restore_cmd: "zstd -d {{ backup_restore_file }} --stdout | tar -xf - -C {{ mms_config_dir }}"
+
+- name: Fix ownership after open-notebook restore
+  ansible.builtin.file:
+    path: "{{ mms_config_dir }}/{{ item }}"
+    state: directory
+    owner: "{{ mms_user }}"
+    group: "{{ mms_user }}"
+    recurse: true
+  become: true
+  become_user: root
+  loop:
+    - open-notebook
+    - open-notebook-db
+
+- name: Start open-notebook services after restore
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: started
+    scope: user
+  environment: "{{ mms_systemd_env }}"
+  loop:
+    - open-notebook-db
+    - open-notebook

--- a/playbooks/tasks/restore/restore-plex.yml
+++ b/playbooks/tasks/restore/restore-plex.yml
@@ -1,0 +1,6 @@
+---
+# Plex restore. Uses the same arr-style extract path as the playbook
+# applies to other services (the bash mms-restore.sh additionally preserves
+# the Plex Cache directory).
+- name: "Dispatch plex restore via arr-style extract"  # noqa: no-relative-paths
+  ansible.builtin.include_tasks: restore-arr.yml

--- a/playbooks/tasks/restore/restore-sabnzbd.yml
+++ b/playbooks/tasks/restore/restore-sabnzbd.yml
@@ -1,0 +1,10 @@
+---
+# SABnzbd-style restore: extract into sabnzbd's config subdirectory.
+- name: "Restore sabnzbd"  # noqa: no-relative-paths
+  ansible.builtin.include_tasks:
+    file: "{{ playbook_dir }}/../roles/backup/tasks/restore_service.yml"
+  vars:
+    _restore_label: sabnzbd
+    _restore_tmp_ext: tar.zst
+    _restore_service: sabnzbd
+    _restore_cmd: "zstd -d {{ backup_restore_file }} --stdout | tar -xf - -C {{ mms_config_dir }}/sabnzbd"

--- a/roles/backup/tasks/load-service-def.yml
+++ b/roles/backup/tasks/load-service-def.yml
@@ -1,0 +1,15 @@
+---
+# Helper: load services/<backup_svc_name>.yml and append it to
+# backup_service_defs_by_name. Called by main.yml in a loop over
+# mms_services so the restore template can read each service's
+# backup_type at render time.
+
+- name: "Load service definition ({{ backup_svc_name }})"
+  ansible.builtin.include_vars:
+    file: "{{ playbook_dir }}/../services/{{ backup_svc_name }}.yml"
+    name: backup_loaded_service_def
+
+- name: "Index service definition ({{ backup_svc_name }})"
+  ansible.builtin.set_fact:
+    backup_service_defs_by_name: >-
+      {{ backup_service_defs_by_name | combine({backup_svc_name: backup_loaded_service_def[backup_svc_name]}) }}

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+# Build an index of services/<name>.yml definitions so mms-restore.sh.j2
+# can dispatch by each service's backup_type instead of hard-coding the case.
+- name: Initialize service definitions index
+  ansible.builtin.set_fact:
+    backup_service_defs_by_name: {}
+
+- name: Index each service definition
+  ansible.builtin.include_tasks: load-service-def.yml
+  loop: "{{ mms_services }}"
+  loop_control:
+    loop_var: backup_svc_name
+
 - name: Ensure backup directory exists
   ansible.builtin.file:
     path: "{{ backup_dir }}"

--- a/roles/backup/templates/mms-restore.sh.j2
+++ b/roles/backup/templates/mms-restore.sh.j2
@@ -3,10 +3,31 @@
 # MMS Restore Script - Decrypt and restore service backups
 set -euo pipefail
 
+{#- Map backup_type -> bash restore function. Services whose backup_type is
+    not in this map are deliberately excluded from the case statement, which
+    preserves today's behavior for services like channels and navidrome that
+    have no restore handler. -#}
+{%- set _restore_function_for_type = {
+    'arr': 'restore_arr',
+    'sabnzbd': 'restore_sabnzbd',
+    'jellyfin': 'restore_jellyfin',
+    'plex': 'restore_plex',
+    'open-notebook': 'restore_open_notebook',
+} -%}
+{#- Build a single list of (service_name, backup_type) tuples from regular
+    services and mms_special_services so the case statement is one loop. -#}
+{%- set _restore_targets = [] -%}
+{%- for svc in mms_services -%}
+{%-   set _ = _restore_targets.append({'name': svc, 'backup_type': backup_service_defs_by_name[svc].backup_type | default('')}) -%}
+{%- endfor -%}
+{%- for svc in mms_special_services | default([]) -%}
+{%-   set _ = _restore_targets.append({'name': svc.name, 'backup_type': svc.backup_type}) -%}
+{%- endfor %}
+
 usage() {
     echo "Usage: $0 <service_name> <backup_file>"
     echo ""
-    echo "Services: {% for svc in mms_services %}{{ svc }}, {% endfor %}traefik, immich, open-notebook"
+    echo "Services: {% for t in _restore_targets %}{{ t.name }}{{ ", " if not loop.last else "" }}{% endfor %}"
     echo ""
     echo "Examples:"
     echo "  $0 radarr /home/{{ backup_user }}/backups/radarr/radarr-2025-01-15.tar.zst.age"
@@ -157,31 +178,21 @@ restore_immich_config() {
 }
 
 case "$SERVICE" in
-    prowlarr|radarr|radarr4k|sonarr|lidarr|tautulli|kometa)
-        restore_arr
-        ;;
-    sabnzbd)
-        restore_sabnzbd
-        ;;
-    jellyfin)
-        restore_jellyfin
-        ;;
-    plex)
-        restore_plex
-        ;;
-    traefik)
-        restore_arr
-        ;;
-    immich)
+{%- for t in _restore_targets %}
+{%-   if t.backup_type == 'immich' %}
+    {{ t.name }})
         if [[ "$BACKUP_FILE" == *db* ]]; then
             restore_immich_db
         else
             restore_immich_config
         fi
         ;;
-    open-notebook)
-        restore_open_notebook
+{%-   elif t.backup_type in _restore_function_for_type %}
+    {{ t.name }})
+        {{ _restore_function_for_type[t.backup_type] }}
         ;;
+{%-   endif %}
+{%- endfor %}
     *)
         echo "Unknown service: $SERVICE"
         usage

--- a/services/channels.yml
+++ b/services/channels.yml
@@ -13,5 +13,5 @@ channels:
     - "TZ={{ mms_timezone }}"
   health_cmd: "curl -sf http://localhost:8089 || exit 1"
   health_interval: "60s"
-  backup_type: "channels"
+  backup_type: "arr"
   backup_db_files: []

--- a/services/navidrome.yml
+++ b/services/navidrome.yml
@@ -15,5 +15,5 @@ navidrome:
     - "ND_ENABLEEXTERNALSERVICES=false"
   health_cmd: "wget -q --spider http://localhost:4533/ping || exit 1"
   health_interval: "60s"
-  backup_type: "navidrome"
+  backup_type: "arr"
   backup_db_files: ["navidrome.db"]

--- a/services/profilarr.yml
+++ b/services/profilarr.yml
@@ -2,7 +2,7 @@
 profilarr:
   name: profilarr
   description: "Profilarr - Quality Profile & Custom Format Manager (v2)"
-  image: "ghcr.io/dictionarry-hub/profilarr:v2.0.0"
+  image: "ghcr.io/dictionarry-hub/profilarr:2.0.0"
   volumes:
     - "{{ mms_config_dir }}/profilarr:/config:Z"
   environment:

--- a/services/profilarr.yml
+++ b/services/profilarr.yml
@@ -1,0 +1,17 @@
+---
+profilarr:
+  name: profilarr
+  description: "Profilarr - Quality Profile & Custom Format Manager (v2)"
+  image: "ghcr.io/dictionarry-hub/profilarr:v2.0.0"
+  volumes:
+    - "{{ mms_config_dir }}/profilarr:/config:Z"
+  environment:
+    - "PUID=0"
+    - "PGID=0"
+    - "UMASK=022"
+    - "TZ={{ mms_timezone }}"
+    - "AUTH=on"
+  health_cmd: "curl -sf http://localhost:6868/api/v1/health || exit 1"
+  health_interval: "60s"
+  backup_type: "arr"
+  backup_db_files: []


### PR DESCRIPTION
## Summary

Closes #91.

- **Refactor restore dispatch** — Both `mms-restore.sh` and `playbooks/restore.yml` now route by each service's `backup_type` instead of hard-coded case/when lists. They read `services/<name>.yml` plus a new `mms_special_services` registry (traefik, immich, open-notebook), so adding a new arr-family service is zero-touch on the restore side.
- **Add Profilarr v2** (`ghcr.io/dictionarry-hub/profilarr:v2.0.0`) as the first service riding the new dispatcher. `backup_type: arr` picks up `restore_arr` automatically. Env contract uses `PUID=0`/`PGID=0` per the LSIO pattern — under rootless Podman with `UserNS=host`, container UID 0 maps to host UID 3000 (the `mms` user), so files in `~mms/config/profilarr/` are owned by `mms:mms`.
- **Align channels and navidrome** with the dispatcher by setting their `backup_type` to `arr`. The bash script already routed them to `restore_arr` via its `else` branch; the playbook was missing handlers, so existing backups could not be restored via Ansible.
- **Defensive assertion** in `playbooks/restore.yml` that fails fast with a listing of supported `backup_type` values if a service declares one without a matching handler — catches future drift instead of surfacing a cryptic missing-file error.

## Test Plan

- [x] `ansible-lint playbooks/ roles/` — 0 failures, 0 warnings (production profile)
- [x] `yamllint .` — clean
- [x] `ansible-playbook playbooks/restore.yml --syntax-check` for channels and profilarr — passes
- [x] Rendered `mms-restore.sh` now contains `channels) restore_arr ;;` and `navidrome) restore_arr ;;` branches
- [x] `shellcheck` on rendered restore script — exit 0
- [x] Profilarr env file expands to `PUID=0` / `PGID=0` (no stale `mms_uid`/`mms_gid` references in `services/`)
- [ ] On-host: `ls -la ~mms/config/profilarr/` after first deploy shows files owned by `mms:mms`
- [ ] On-host: `podman exec profilarr id` reports container UID 0 (mapped to host UID 3000)