### PR TITLE
docs(wiki): comprehensive review fixes (B/H/M/L)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -156,7 +156,7 @@
         "filename": "docs/wiki/Backup-and-Restore.md",
         "hashed_secret": "3208da94e19c447a18e0f35b6603070ce94150d7",
         "is_verified": false,
-        "line_number": 134
+        "line_number": 136
       }
     ],
     "inventory/group_vars/all/vault.yml.example": [
@@ -217,5 +217,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-20T21:43:49Z"
+  "generated_at": "2026-05-18T13:24:54Z"
 }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ See the **[Getting Started](https://github.com/randomparity/max-media-stack/wiki
 
 ## Documentation
 
-Full documentation is in the **[Wiki](https://github.com/randomparity/max-media-stack/wiki)** (source: [`docs/wiki/`](docs/wiki/), synced on merge to `main`):
+Full documentation is in the **[Wiki](https://github.com/randomparity/max-media-stack/wiki)** (source: [`docs/wiki/`](docs/wiki/), synced on merge to `main`). Per-service runbooks (Profilarr, Channels DVR, Navidrome, Open Notebook, Observability, etc.) are linked from the wiki sidebar.
+
+See [AGENTS.md](AGENTS.md) for the contributor / agent-facing summary (Codex CLI compatible).
 
 | Topic | Description |
 |-------|-------------|

--- a/docs/wiki/Adding-a-New-Service.md
+++ b/docs/wiki/Adding-a-New-Service.md
@@ -4,23 +4,27 @@ MMS uses a data-driven approach -- each service is defined in a YAML file and re
 
 ## 1. Create the service definition
 
-Create `services/<name>.yml` with the service configuration:
+Create `services/<name>.yml` as a nested map keyed by the service name. The `quadlet_service` role reads this top-level key when rendering the Quadlet template.
 
 ```yaml
+---
 # services/myservice.yml
-service_image: "lscr.io/linuxserver/myservice:1.2.3"
-service_port: 8080
-service_volumes:
-  - "{{ mms_config_dir }}/myservice:/config:Z"
-  - "/data/media:/media"
-service_healthcheck:
-  test: "curl -f http://localhost:8080 || exit 1"
-  interval: "30s"
-  timeout: "10s"
-  retries: 3
+myservice:
+  name: myservice
+  description: "MyService - short description"
+  image: "ghcr.io/example/myservice:1.2.3"
+  volumes:
+    - "{{ mms_config_dir }}/myservice:/config:Z"
+    - "/data/media:/media"
+  environment:
+    - "TZ={{ mms_timezone }}"
+  health_cmd: "curl -sf http://localhost:8080/ || exit 1"
+  health_interval: "60s"
+  backup_type: "arr"
+  backup_db_files: []
 ```
 
-Look at existing files in `services/` for examples of the full set of available options (environment variables, tmpfs mounts, labels, etc.).
+Look at existing files in `services/` for examples of the full set of available options (`publish_ports`, `userns`, `user`, additional `tmpfs` entries, `no_new_privileges`, etc.). `services/profilarr.yml` is a good minimal template.
 
 ## 2. Add to the services list
 
@@ -72,12 +76,15 @@ The data-driven `quadlet_service` pattern works for single-container services. M
 
 ## Backup and restore
 
-Declare `backup_type` in the service file. Both `mms-backup.sh` and `mms-restore.sh` dispatch on this value, as does `playbooks/restore.yml`. Currently understood values:
+Declare `backup_type` in the service file. Both `mms-backup.sh` and `mms-restore.sh` dispatch on this value, as does `playbooks/restore.yml`. The supported values, and the services that currently use each, are:
 
-- `arr` — generic stop/tar/start. Use for any *arr-family service or anything with a single config directory.
-- `sabnzbd` — extracts into the service's own subdirectory.
-- `jellyfin` / `plex` — bash restore preserves the cache directory.
-- `immich` — multi-container; backup includes a PostgreSQL dump.
-- `open-notebook` — cold backup of both the app and SurrealDB directories.
+- `arr` — generic stop/tar/start. Used by prowlarr, profilarr, radarr, radarr4k, sonarr, lidarr, tautulli, kometa, channels, navidrome, and traefik (via `mms_special_services`). Reuse this for any service with a single config directory.
+- `sabnzbd` — used by sabnzbd; extracts into the service's own subdirectory.
+- `jellyfin` — used by jellyfin; bash restore excludes the cache directory.
+- `plex` — used by plex; stops the service and excludes regenerable directories (Cache, Crash Reports, Updates, Codecs).
+- `immich` — used by immich; multi-container restore including a PostgreSQL dump.
+- `open-notebook` — used by open-notebook (via `mms_special_services`); cold backup of both the app and SurrealDB directories.
+
+The whitelist is enforced in `playbooks/restore.yml`; declaring a value outside this list causes the restore playbook to fail before dispatch.
 
 Adding a new value requires adding the corresponding restore function in `roles/backup/templates/mms-restore.sh.j2` (bash side) and a `playbooks/tasks/restore/restore-<type>.yml` (playbook side). Existing values just work; e.g. `backup_type: arr` for a new *arr-family service needs no additional code.

--- a/docs/wiki/Auto-Deploy.md
+++ b/docs/wiki/Auto-Deploy.md
@@ -157,6 +157,7 @@ autodeploy_groups:
     schedule: "*-*-* *:00/30:00"
     services:
       - prowlarr
+      - profilarr
       - radarr
       - radarr4k
       - sonarr
@@ -178,3 +179,9 @@ autodeploy_groups:
 ```
 
 When `services` is omitted from a group, the playbook deploys everything. When specified, only the listed services are deployed when the group's timer fires.
+
+## Renovate dependency dashboard
+
+Renovate maintains a single "Dependency Dashboard" issue per repository (filed by `renovate[bot]`) that summarises all detected updates, the schedule each is on, any rate-limited PRs, and pending major bumps that need manual review. It is the fastest way to see what Renovate is about to do — or why it is not doing something you expected.
+
+To find it, filter the repository's **Issues** by author `renovate[bot]`, or browse to the open issue titled `Dependency Dashboard`. Each line links to the PR Renovate will open (or has already opened); checking a box requests that Renovate create the corresponding PR immediately rather than waiting for its next schedule slot.

--- a/docs/wiki/Channels-DVR.md
+++ b/docs/wiki/Channels-DVR.md
@@ -8,7 +8,7 @@ Live TV and DVR server -- records TV from HDHomeRun tuners and streaming sources
 | **Container name** | `channels` |
 | **Internal port** | 8089 |
 | **Published port** | 8089 (host) -> 8089 (container) |
-| **Traefik subdomain** | `channels.media.drc.nz` |
+| **Traefik subdomain** | `channels.media.example.com` |
 | **Config directory** | `/home/mms/config/channels` |
 | **Recordings directory** | `/data/recordings` (NFS) |
 | **Health endpoint** | `http://localhost:8089` |
@@ -37,7 +37,7 @@ podman logs --tail 50 channels
 ```bash
 podman healthcheck run channels
 podman exec channels curl -sf http://localhost:8089
-curl -sf http://channels.media.drc.nz
+curl -sf http://channels.media.example.com
 
 # Also accessible on the published port
 curl -sf http://localhost:8089

--- a/docs/wiki/Channels-DVR.md
+++ b/docs/wiki/Channels-DVR.md
@@ -12,7 +12,7 @@ Live TV and DVR server -- records TV from HDHomeRun tuners and streaming sources
 | **Config directory** | `/home/mms/config/channels` |
 | **Recordings directory** | `/data/recordings` (NFS) |
 | **Health endpoint** | `http://localhost:8089` |
-| **Backup type** | `channels` (config backup only) |
+| **Backup type** | `arr` (config backup only) |
 | **Autodeploy group** | `interactive` (daily at 02:00) |
 
 ## Service Management

--- a/docs/wiki/Channels-DVR.md
+++ b/docs/wiki/Channels-DVR.md
@@ -4,7 +4,7 @@ Live TV and DVR server -- records TV from HDHomeRun tuners and streaming sources
 
 | Property | Value |
 |----------|-------|
-| **Image** | `fancybits/channels-dvr` (Official, digest-pinned) |
+| **Image** | `fancybits/channels-dvr` (vendor image, digest-pinned) |
 | **Container name** | `channels` |
 | **Internal port** | 8089 |
 | **Published port** | 8089 (host) -> 8089 (container) |

--- a/docs/wiki/Common-Operations.md
+++ b/docs/wiki/Common-Operations.md
@@ -1,6 +1,6 @@
 # Common Operations
 
-Day-to-day commands for managing the media stack.
+Day-to-day commands for managing the media stack. Sections below cover deployment (single service, all services, full site), backup, restore, migration from existing LXC containers, lint, image pruning, log inspection, and dry-run/check-mode workflows.
 
 ## Deploy a single service
 

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -2,6 +2,8 @@
 
 MMS uses Ansible inventory variables and vault-encrypted secrets to configure the deployment.
 
+Examples throughout the wiki use `media.example.com` as the placeholder domain; replace it with your own `mms_traefik_domain` (set in `inventory/group_vars/all/vars.yml`).
+
 ## Inventory files
 
 ### `inventory/group_vars/all/vars.yml`

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -29,6 +29,7 @@ Service-level configuration:
 
 - NFS mount definitions
 - Services list (`mms_services`)
+- Special services registry (`mms_special_services`) -- non-`services/` deployments (traefik, immich, open-notebook) with their `backup_type` for restore dispatch
 - Traefik routes (`mms_traefik_routes`)
 - Autodeploy config (`mms_autodeploy_repo_url`, `autodeploy_groups`)
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -15,7 +15,7 @@ Ansible project to provision and manage a full homelab media stack on a Fedora V
 | Jellyfin  | `jellyfin.media.example.com`     | Media server                   |
 | Plex      | `plex.media.example.com`         | Media server                   |
 | Tautulli  | `tautulli.media.example.com`     | Plex analytics/monitoring      |
-| Kometa    | ---                              | Plex metadata manager (no UI)  |
+| Kometa    | —                                | Plex metadata manager (no UI)  |
 | Immich    | `immich.media.example.com`       | Photo/video management         |
 | Channels  | `channels.media.example.com`     | Live TV and DVR                |
 | Navidrome | `navidrome.media.example.com`    | Music streaming server         |

--- a/docs/wiki/Immich.md
+++ b/docs/wiki/Immich.md
@@ -11,7 +11,7 @@ Self-hosted photo and video management -- provides Google Photos-like features w
 
 | Property | Value |
 |----------|-------|
-| **Traefik subdomain** | `immich.media.drc.nz` |
+| **Traefik subdomain** | `immich.media.example.com` |
 | **Config directory** | `/home/mms/config/immich` |
 | **Local media directory** | `/home/mms/config/immich/media` (SSD, generated content) |
 | **NFS upload directory** | `/data/photos` (user content) |
@@ -76,7 +76,7 @@ journalctl --user -u immich-server --since today
 ```bash
 # Server health
 podman healthcheck run immich-server
-curl -sf http://immich.media.drc.nz/api/server/ping
+curl -sf http://immich.media.example.com/api/server/ping
 
 # PostgreSQL health
 podman healthcheck run immich-postgres

--- a/docs/wiki/Jellyfin.md
+++ b/docs/wiki/Jellyfin.md
@@ -7,7 +7,7 @@ Free and open-source media server -- streams movies, TV shows, and music to clie
 | **Image** | `docker.io/jellyfin/jellyfin` (Official) |
 | **Container name** | `jellyfin` |
 | **Internal port** | 8096 |
-| **Traefik subdomain** | `jellyfin.media.drc.nz` |
+| **Traefik subdomain** | `jellyfin.media.example.com` |
 | **Config directory** | `/home/mms/config/jellyfin` |
 | **Media directory** | `/data/media` (NFS, read-only) |
 | **Health endpoint** | `http://localhost:8096/health` |
@@ -36,7 +36,7 @@ podman logs --tail 50 jellyfin
 ```bash
 podman healthcheck run jellyfin
 podman exec jellyfin curl -sf http://localhost:8096/health
-curl -sf http://jellyfin.media.drc.nz/health
+curl -sf http://jellyfin.media.example.com/health
 ```
 
 ## Manual Testing

--- a/docs/wiki/Lidarr.md
+++ b/docs/wiki/Lidarr.md
@@ -7,7 +7,7 @@ Music collection manager -- monitors for new releases, searches indexers, and se
 | **Image** | `lscr.io/linuxserver/lidarr` (LSIO) |
 | **Container name** | `lidarr` |
 | **Internal port** | 8686 |
-| **Traefik subdomain** | `lidarr.media.drc.nz` |
+| **Traefik subdomain** | `lidarr.media.example.com` |
 | **Config directory** | `/home/mms/config/lidarr` |
 | **Data directory** | `/data` (NFS -- music, usenet) |
 | **Health endpoint** | `http://localhost:8686/ping` |
@@ -36,7 +36,7 @@ podman logs --tail 50 lidarr
 ```bash
 podman healthcheck run lidarr
 podman exec lidarr curl -sf http://localhost:8686/ping
-curl -sf http://lidarr.media.drc.nz/ping
+curl -sf http://lidarr.media.example.com/ping
 ```
 
 ## Manual Testing

--- a/docs/wiki/Navidrome.md
+++ b/docs/wiki/Navidrome.md
@@ -11,7 +11,7 @@ Music streaming server -- provides a Subsonic-compatible API for music playback 
 | **Config directory** | `/home/mms/config/navidrome` |
 | **Music directory** | `/data/media/music` (NFS, read-only) |
 | **Health endpoint** | `http://localhost:4533/ping` |
-| **Backup type** | `navidrome` (config backup) |
+| **Backup type** | `arr` (config backup only) |
 | **Autodeploy group** | `interactive` (daily at 02:00) |
 
 ## Service Management

--- a/docs/wiki/Navidrome.md
+++ b/docs/wiki/Navidrome.md
@@ -7,7 +7,7 @@ Music streaming server -- provides a Subsonic-compatible API for music playback 
 | **Image** | `deluan/navidrome` (Official) |
 | **Container name** | `navidrome` |
 | **Internal port** | 4533 |
-| **Traefik subdomain** | `navidrome.media.drc.nz` |
+| **Traefik subdomain** | `navidrome.media.example.com` |
 | **Config directory** | `/home/mms/config/navidrome` |
 | **Music directory** | `/data/media/music` (NFS, read-only) |
 | **Health endpoint** | `http://localhost:4533/ping` |
@@ -42,7 +42,7 @@ podman healthcheck run navidrome
 podman exec navidrome wget -q --spider http://localhost:4533/ping
 
 # Via Traefik
-curl -sf http://navidrome.media.drc.nz/ping
+curl -sf http://navidrome.media.example.com/ping
 ```
 
 ## Manual Testing

--- a/docs/wiki/Observability.md
+++ b/docs/wiki/Observability.md
@@ -20,7 +20,7 @@ Prometheus and Loki will repopulate from live data. **None require backup.**
 
 | Property | Value |
 |----------|-------|
-| **Traefik subdomain** | `grafana.media.drc.nz` (Grafana only) |
+| **Traefik subdomain** | `grafana.media.example.com` (Grafana only) |
 | **Config directory** | `/home/mms/config/logging` |
 | **Loki data** | `/home/mms/config/logging/loki-data` |
 | **Grafana data** | `/home/mms/config/logging/grafana-data` |
@@ -536,7 +536,7 @@ curl -sf http://127.0.0.1:3100/ready
 curl -sf http://localhost:9090/api/v1/targets | python3 -m json.tool
 
 # Grafana UI
-curl -sf http://grafana.media.drc.nz/api/health
+curl -sf http://grafana.media.example.com/api/health
 ```
 
 ## Backup & Restore

--- a/docs/wiki/Observability.md
+++ b/docs/wiki/Observability.md
@@ -27,7 +27,7 @@ Prometheus and Loki will repopulate from live data. **None require backup.**
 | **Prometheus data** | `/home/mms/config/logging/prometheus-data` |
 | **Prometheus retention** | 30 days |
 | **Loki retention** | 30 days (720h) |
-| **Log inspection timer** | Every 15 minutes |
+| **Log inspection timer** | Every 15 minutes (configurable via `logging_inspection_schedule`) |
 | **Log inspection policies** | `/home/mms/config/logging/inspection/policies` |
 | **Latest inspection report** | `/home/mms/config/logging/inspection/latest-report.json` |
 | **Notification env file** | `/home/mms/config/logging/inspection/notifications.env` |

--- a/docs/wiki/Open-Notebook.md
+++ b/docs/wiki/Open-Notebook.md
@@ -9,7 +9,7 @@ AI-powered notebook application -- provides a web interface for note-taking with
 
 | Property | Value |
 |----------|-------|
-| **Traefik subdomain** | `notebook.media.drc.nz` |
+| **Traefik subdomain** | `notebook.media.example.com` |
 | **App config directory** | `/home/mms/config/open-notebook` |
 | **DB config directory** | `/home/mms/config/open-notebook-db` |
 | **Backup type** | Cold backup (both containers stopped) |

--- a/docs/wiki/Plex.md
+++ b/docs/wiki/Plex.md
@@ -8,7 +8,7 @@ Media server with rich client support -- streams movies, TV shows, and music. Th
 | **Container name** | `plex` |
 | **Internal port** | 32400 |
 | **Published port** | 32400 (host) -> 32400 (container) |
-| **Traefik subdomain** | `plex.media.drc.nz` |
+| **Traefik subdomain** | `plex.media.example.com` |
 | **Config directory** | `/home/mms/config/plex` |
 | **Media directories** | `/data/media/movies`, `/data/media/series`, `/data/media/music` (NFS, read-only) |
 | **Health endpoint** | `http://localhost:32400/identity` |
@@ -37,7 +37,7 @@ podman logs --tail 50 plex
 ```bash
 podman healthcheck run plex
 podman exec plex curl -sf http://localhost:32400/identity
-curl -sf http://plex.media.drc.nz/identity
+curl -sf http://plex.media.example.com/identity
 
 # Also accessible directly on the published port
 curl -sf http://localhost:32400/identity
@@ -111,7 +111,7 @@ Plex also publishes port 32400 directly for client compatibility (some Plex clie
 
 **Plex not accessible via Traefik**
 
-Plex works via both Traefik (`plex.media.drc.nz`) and direct port 32400. If Traefik routing fails but direct access works, the issue is with Traefik configuration. See [Traefik](Traefik).
+Plex works via both Traefik (`plex.media.example.com`) and direct port 32400. If Traefik routing fails but direct access works, the issue is with Traefik configuration. See [Traefik](Traefik).
 
 **"Not authorized" after restore**
 

--- a/docs/wiki/Profilarr.md
+++ b/docs/wiki/Profilarr.md
@@ -7,7 +7,7 @@ Quality Profile and Custom Format manager for Radarr/Sonarr/Lidarr. Profilarr v2
 | **Image** | `ghcr.io/dictionarry-hub/profilarr` |
 | **Container name** | `profilarr` |
 | **Internal port** | 6868 |
-| **Traefik subdomain** | `profilarr.media.drc.nz` |
+| **Traefik subdomain** | `profilarr.media.example.com` |
 | **Config directory** | `/home/mms/config/profilarr` |
 | **Health endpoint** | `http://localhost:6868/api/v1/health` |
 | **Backup type** | `arr` (config backup) |
@@ -37,7 +37,7 @@ podman logs -f profilarr
 ```bash
 podman healthcheck run profilarr
 podman exec profilarr curl -sf http://localhost:6868/api/v1/health
-curl -sf http://profilarr.media.drc.nz/api/v1/health
+curl -sf http://profilarr.media.example.com/api/v1/health
 ```
 
 ## Backup & Restore

--- a/docs/wiki/Prowlarr.md
+++ b/docs/wiki/Prowlarr.md
@@ -7,7 +7,7 @@ Indexer manager for Usenet and torrent trackers -- provides unified search acros
 | **Image** | `lscr.io/linuxserver/prowlarr` (LSIO) |
 | **Container name** | `prowlarr` |
 | **Internal port** | 9696 |
-| **Traefik subdomain** | `prowlarr.media.drc.nz` |
+| **Traefik subdomain** | `prowlarr.media.example.com` |
 | **Config directory** | `/home/mms/config/prowlarr` |
 | **Health endpoint** | `http://localhost:9696/ping` |
 | **Backup type** | `arr` (API backup + config backup) |
@@ -44,7 +44,7 @@ podman healthcheck run prowlarr
 podman exec prowlarr curl -sf http://localhost:9696/ping
 
 # Via Traefik
-curl -sf http://prowlarr.media.drc.nz/ping
+curl -sf http://prowlarr.media.example.com/ping
 ```
 
 ## Manual Testing

--- a/docs/wiki/Radarr-4K.md
+++ b/docs/wiki/Radarr-4K.md
@@ -9,7 +9,7 @@ Second Radarr instance for managing 4K movie downloads separately from the stand
 | **Image** | `lscr.io/linuxserver/radarr` (LSIO) -- same image as Radarr |
 | **Container name** | `radarr4k` |
 | **Internal port** | 7878 |
-| **Traefik subdomain** | `radarr4k.media.drc.nz` |
+| **Traefik subdomain** | `radarr4k.media.example.com` |
 | **Config directory** | `/home/mms/config/radarr4k` |
 | **Data directory** | `/data` (NFS) |
 | **Health endpoint** | `http://localhost:7878/ping` |
@@ -29,7 +29,7 @@ systemctl --user status radarr4k.service
 
 - **Container name**: `radarr4k` (not `radarr`)
 - **Config directory**: `/home/mms/config/radarr4k` (separate database and config)
-- **Traefik subdomain**: `radarr4k.media.drc.nz`
+- **Traefik subdomain**: `radarr4k.media.example.com`
 - **Quality profiles**: Configured for 4K/UHD content
 - **Root folder**: Typically points to a separate 4K movies directory under `/data`
 

--- a/docs/wiki/Radarr.md
+++ b/docs/wiki/Radarr.md
@@ -7,7 +7,7 @@ Movie collection manager -- monitors for new releases, searches indexers, and se
 | **Image** | `lscr.io/linuxserver/radarr` (LSIO) |
 | **Container name** | `radarr` |
 | **Internal port** | 7878 |
-| **Traefik subdomain** | `radarr.media.drc.nz` |
+| **Traefik subdomain** | `radarr.media.example.com` |
 | **Config directory** | `/home/mms/config/radarr` |
 | **Data directory** | `/data` (NFS -- movies, usenet) |
 | **Health endpoint** | `http://localhost:7878/ping` |
@@ -45,7 +45,7 @@ podman healthcheck run radarr
 podman exec radarr curl -sf http://localhost:7878/ping
 
 # Via Traefik
-curl -sf http://radarr.media.drc.nz/ping
+curl -sf http://radarr.media.example.com/ping
 ```
 
 ## Manual Testing

--- a/docs/wiki/SABnzbd.md
+++ b/docs/wiki/SABnzbd.md
@@ -7,7 +7,7 @@ Usenet download client -- receives NZB files from Radarr, Sonarr, and Lidarr and
 | **Image** | `lscr.io/linuxserver/sabnzbd` (LSIO) |
 | **Container name** | `sabnzbd` |
 | **Internal port** | 8080 |
-| **Traefik subdomain** | `sabnzbd.media.drc.nz` |
+| **Traefik subdomain** | `sabnzbd.media.example.com` |
 | **Config directory** | `/home/mms/config/sabnzbd` |
 | **Data directory** | `/data` (NFS -- usenet downloads) |
 | **Health endpoint** | `http://localhost:8080/api?mode=version` |
@@ -36,7 +36,7 @@ podman logs --tail 50 sabnzbd
 ```bash
 podman healthcheck run sabnzbd
 podman exec sabnzbd curl -sf http://localhost:8080/api?mode=version
-curl -sf http://sabnzbd.media.drc.nz/api?mode=version
+curl -sf http://sabnzbd.media.example.com/api?mode=version
 ```
 
 ## Manual Testing
@@ -93,10 +93,10 @@ SABnzbd restricts access by hostname. The MMS deployment uses an INI stop-then-a
 
 ```ini
 [misc]
-host_whitelist = sabnzbd.media.drc.nz,sabnzbd
+host_whitelist = sabnzbd.media.example.com,sabnzbd
 ```
 
-The whitelist must include **both** the Traefik FQDN (`sabnzbd.media.drc.nz`) and the bare container hostname (`sabnzbd`). The bare hostname is needed for inter-container connections from the *arr services.
+The whitelist must include **both** the Traefik FQDN (`sabnzbd.media.example.com`) and the bare container hostname (`sabnzbd`). The bare hostname is needed for inter-container connections from the *arr services.
 
 If you see access denied errors after a manual config change:
 

--- a/docs/wiki/Sonarr.md
+++ b/docs/wiki/Sonarr.md
@@ -7,7 +7,7 @@ TV series collection manager -- monitors for new episodes, searches indexers, an
 | **Image** | `lscr.io/linuxserver/sonarr` (LSIO) |
 | **Container name** | `sonarr` |
 | **Internal port** | 8989 |
-| **Traefik subdomain** | `sonarr.media.drc.nz` |
+| **Traefik subdomain** | `sonarr.media.example.com` |
 | **Config directory** | `/home/mms/config/sonarr` |
 | **Data directory** | `/data` (NFS -- series, usenet) |
 | **Health endpoint** | `http://localhost:8989/ping` |
@@ -36,7 +36,7 @@ podman logs --tail 50 sonarr
 ```bash
 podman healthcheck run sonarr
 podman exec sonarr curl -sf http://localhost:8989/ping
-curl -sf http://sonarr.media.drc.nz/ping
+curl -sf http://sonarr.media.example.com/ping
 ```
 
 ## Manual Testing

--- a/docs/wiki/Tautulli.md
+++ b/docs/wiki/Tautulli.md
@@ -7,7 +7,7 @@ Plex analytics and monitoring -- tracks viewing history, provides notifications,
 | **Image** | `lscr.io/linuxserver/tautulli` (LSIO) |
 | **Container name** | `tautulli` |
 | **Internal port** | 8181 |
-| **Traefik subdomain** | `tautulli.media.drc.nz` |
+| **Traefik subdomain** | `tautulli.media.example.com` |
 | **Config directory** | `/home/mms/config/tautulli` |
 | **Health endpoint** | `http://localhost:8181/status` |
 | **Backup type** | `arr` (config backup only, no API backup) |
@@ -36,7 +36,7 @@ podman logs --tail 50 tautulli
 ```bash
 podman healthcheck run tautulli
 podman exec tautulli curl -sf http://localhost:8181/status
-curl -sf http://tautulli.media.drc.nz/status
+curl -sf http://tautulli.media.example.com/status
 ```
 
 ## Manual Testing

--- a/docs/wiki/Traefik.md
+++ b/docs/wiki/Traefik.md
@@ -38,8 +38,8 @@ podman logs --tail 50 traefik
 curl -s -o /dev/null -w "%{http_code}" http://localhost
 
 # Test a specific route
-curl -sf -H "Host: radarr.media.drc.nz" http://localhost
-curl -sf http://radarr.media.drc.nz
+curl -sf -H "Host: radarr.media.example.com" http://localhost
+curl -sf http://radarr.media.example.com
 ```
 
 ## Manual Testing
@@ -85,7 +85,7 @@ cat ~/config/traefik/dynamic/*.yml
 # Test each service route
 for svc in prowlarr radarr radarr4k sonarr lidarr sabnzbd jellyfin plex tautulli channels navidrome immich notebook grafana; do
   echo -n "$svc: "
-  curl -s -o /dev/null -w "%{http_code}" -H "Host: ${svc}.media.drc.nz" http://localhost
+  curl -s -o /dev/null -w "%{http_code}" -H "Host: ${svc}.media.example.com" http://localhost
   echo
 done
 
@@ -105,11 +105,11 @@ Traefik is running but the route doesn't match the `Host` header. Check:
    ```
 2. DNS resolves correctly:
    ```bash
-   dig radarr.media.drc.nz
+   dig radarr.media.example.com
    ```
 3. The `Host` header matches exactly:
    ```bash
-   curl -v -H "Host: radarr.media.drc.nz" http://localhost
+   curl -v -H "Host: radarr.media.example.com" http://localhost
    ```
 
 **502 Bad Gateway / connection refused to backend**
@@ -133,7 +133,7 @@ The wildcard DNS record may not be configured. See [Traefik Reverse Proxy](Traef
 
 ```bash
 # Add to /etc/hosts on the client
-echo "<tailscale-ip> radarr.media.drc.nz sonarr.media.drc.nz" | sudo tee -a /etc/hosts
+echo "<tailscale-ip> radarr.media.example.com sonarr.media.example.com" | sudo tee -a /etc/hosts
 ```
 
 **Routes not updating after deploy**

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -9,6 +9,7 @@
 - [Storage Layout](Storage-Layout)
 - [Traefik Reverse Proxy](Traefik-Reverse-Proxy)
 - [Security](Security)
+- [Observability](Observability)
 
 **Services**
 - [Prowlarr](Prowlarr)
@@ -27,7 +28,6 @@
 - [Immich](Immich)
 - [Open Notebook](Open-Notebook)
 - [Traefik](Traefik)
-- [Observability](Observability)
 
 **Operations**
 - [Common Operations](Common-Operations)


### PR DESCRIPTION
## Summary

Applies the comprehensive wiki documentation review (2 BLOCKER, 4 HIGH, 6 MEDIUM, 6 LOW) across the wiki, README, and supporting docs.

- **BLOCKER (2):** `docs/wiki/Navidrome.md` and `docs/wiki/Channels-DVR.md` documented `backup_type` values (`navidrome`, `channels`) that did not match `services/*.yml`. The asserted whitelist in `playbooks/restore.yml` is `[arr, sabnzbd, jellyfin, plex, immich, open-notebook]`, so a restore attempt against either service would have hard-failed. Both are now `arr`, matching the canonical service definitions.
- **HIGH (4):** Expanded the `backup_type` enumeration in `Adding-a-New-Service.md` (so contributors don't invent new values); added a wiki-sidebar pointer plus an `AGENTS.md` reference to `README.md`; added `profilarr` to the backend autodeploy group example; documented `mms_special_services` under `Configuration.md`.
- **MEDIUM (6):** Channels-DVR image relabeled as "vendor image" rather than "Official"; `Common-Operations.md` intro previews all sections; `_Sidebar.md` moves Observability out of Services into Architecture (5-container cross-cutting stack); annotated the 15-minute log-inspection cadence with `logging_inspection_schedule`; standardized on `media.example.com` as the placeholder domain (16 wiki pages, ~38 instances) and added a clarifying sentence to `Configuration.md`.
- **LOW (6):** Em-dash fix in `Home.md`; verified no trailing whitespace in `README.md:24` (L2 not present); rewrote the `Adding-a-New-Service.md` example to match the real `services/<name>.yml` schema (using `services/profilarr.yml` as the template); added a Renovate dependency dashboard section to `Auto-Deploy.md`.

## Commits

1. `docs(wiki): fix incorrect backup_type values for navidrome and channels` — BLOCKERs in isolation.
2. `docs(wiki): align service docs with current state` — all H + M + L except the domain sweep.
3. `docs(wiki): standardize on media.example.com placeholder domain` — sweep across 17 files.
4. `chore: refresh detect-secrets baseline` — stale line-number pointer from upstream merge.

## Verification

- `grep -n 'Backup type' docs/wiki/Navidrome.md docs/wiki/Channels-DVR.md` → both `arr`.
- `rg -n 'media\.drc\.nz' docs/ README.md AGENTS.md CLAUDE.md` → no matches.
- Sidebar links resolve to existing files.
- `playbooks/restore.yml` whitelist unchanged; every `services/*.yml` `backup_type` is in the whitelist.
- `prek run --all-files` clean (detect-secrets, yamllint, ansible-lint, trailing whitespace).

## Test plan

- [ ] Verify wiki preview renders (links in `_Sidebar.md` resolve to existing pages).
- [ ] Spot-check Navidrome / Channels-DVR pages for the `arr` `backup_type` row.
- [ ] Confirm the `Adding-a-New-Service.md` schema example matches a real `services/<name>.yml` file.

## Out of scope

- Splitting the 672-line `Observability.md` into sub-pages.
- Creating standalone `Backup-Types.md` or `Variables.md` reference pages.
- Adding `CONTRIBUTING.md` / `LICENSE` (intentionally absent for a personal homelab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)