### PR TITLE
build(deps): require proxmoxer >= 2.3.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,6 @@ yamllint>=1.33
 molecule>=24.0
 molecule-plugins[docker]>=24.0
 pre-commit>=3.0
-proxmoxer>=2.0
+proxmoxer>=2.3.0
 requests>=2.30
 pytest==9.0.3


### PR DESCRIPTION
## What

Bump the `proxmoxer` dev dependency floor from `>=2.0` to `>=2.3.0` in `requirements-dev.txt`.

## Why

`community.proxmox` 2.0.0 (incoming via the Renovate major-collections update) requires `proxmoxer >= 2.3.0`. The `proxmox_kvm`, `proxmox_vm_info`, `proxmox_disk`, and `proxmox_snap` modules used by the `proxmox_vm` and `migrate` roles will fail to import an older proxmoxer. Pinning the floor enforces the prerequisite on the control node that runs provisioning/migration.

Note: this requirement does not affect the autodeploy host — `deploy-services.yml` does not invoke proxmox modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)