### PR TITLE
build(deps): align ansible-core with Fedora 43 host + robust restore includes

### DIFF
--- a/playbooks/tasks/restore/restore-arr.yml
+++ b/playbooks/tasks/restore/restore-arr.yml
@@ -1,11 +1,12 @@
 ---
 # Generic "stop, extract tar to config dir, start" restore.
 # Used for backup_type=arr services (prowlarr, profilarr, *arr, tautulli, kometa, traefik).
-- name: "Restore standard service ({{ service_name }})"  # noqa: no-relative-paths
-  ansible.builtin.include_tasks:
-    file: "{{ playbook_dir }}/../roles/backup/tasks/restore_service.yml"
+- name: "Restore standard service ({{ service_name }})"
+  ansible.builtin.include_role:
+    name: backup
+    tasks_from: restore_service
   vars:
-    _restore_label: "{{ service_name }}"
-    _restore_tmp_ext: tar.zst
-    _restore_service: "{{ service_name }}"
-    _restore_cmd: "zstd -d {{ backup_restore_file }} --stdout | tar -xf - -C {{ mms_config_dir }}"
+    backup_restore_label: "{{ service_name }}"
+    backup_restore_tmp_ext: tar.zst
+    backup_restore_service: "{{ service_name }}"
+    backup_restore_cmd: "zstd -d {{ backup_restore_file }} --stdout | tar -xf - -C {{ mms_config_dir }}"

--- a/playbooks/tasks/restore/restore-immich.yml
+++ b/playbooks/tasks/restore/restore-immich.yml
@@ -1,24 +1,26 @@
 ---
 # Immich restore: branches on the backup filename. A file containing
 # "db" restores the PostgreSQL dump; otherwise restore the config tar.
-- name: "Restore immich database"  # noqa: no-relative-paths
-  ansible.builtin.include_tasks:
-    file: "{{ playbook_dir }}/../roles/backup/tasks/restore_service.yml"
+- name: "Restore immich database"
+  ansible.builtin.include_role:
+    name: backup
+    tasks_from: restore_service
   vars:
-    _restore_label: immich-db
-    _restore_tmp_ext: sql.zst
-    _restore_service: ""
-    _restore_cmd: >-
+    backup_restore_label: immich-db
+    backup_restore_tmp_ext: sql.zst
+    backup_restore_service: ""
+    backup_restore_cmd: >-
       zstd -d {{ backup_restore_file }} --stdout |
       podman exec -i immich-postgres psql -U postgres
   when: "'db' in backup_file"
 
-- name: "Restore immich config"  # noqa: no-relative-paths
-  ansible.builtin.include_tasks:
-    file: "{{ playbook_dir }}/../roles/backup/tasks/restore_service.yml"
+- name: "Restore immich config"
+  ansible.builtin.include_role:
+    name: backup
+    tasks_from: restore_service
   vars:
-    _restore_label: immich-config
-    _restore_tmp_ext: tar.zst
-    _restore_service: ""
-    _restore_cmd: "zstd -d {{ backup_restore_file }} --stdout | tar -xf - -C {{ mms_config_dir }}"
+    backup_restore_label: immich-config
+    backup_restore_tmp_ext: tar.zst
+    backup_restore_service: ""
+    backup_restore_cmd: "zstd -d {{ backup_restore_file }} --stdout | tar -xf - -C {{ mms_config_dir }}"
   when: "'db' not in backup_file"

--- a/playbooks/tasks/restore/restore-open-notebook.yml
+++ b/playbooks/tasks/restore/restore-open-notebook.yml
@@ -13,14 +13,15 @@
     - open-notebook-db
   failed_when: false
 
-- name: "Restore open-notebook"  # noqa: no-relative-paths
-  ansible.builtin.include_tasks:
-    file: "{{ playbook_dir }}/../roles/backup/tasks/restore_service.yml"
+- name: "Restore open-notebook"
+  ansible.builtin.include_role:
+    name: backup
+    tasks_from: restore_service
   vars:
-    _restore_label: open-notebook
-    _restore_tmp_ext: tar.zst
-    _restore_service: ""
-    _restore_cmd: "zstd -d {{ backup_restore_file }} --stdout | tar -xf - -C {{ mms_config_dir }}"
+    backup_restore_label: open-notebook
+    backup_restore_tmp_ext: tar.zst
+    backup_restore_service: ""
+    backup_restore_cmd: "zstd -d {{ backup_restore_file }} --stdout | tar -xf - -C {{ mms_config_dir }}"
 
 - name: Fix ownership after open-notebook restore
   ansible.builtin.file:

--- a/playbooks/tasks/restore/restore-sabnzbd.yml
+++ b/playbooks/tasks/restore/restore-sabnzbd.yml
@@ -1,10 +1,11 @@
 ---
 # SABnzbd-style restore: extract into sabnzbd's config subdirectory.
-- name: "Restore sabnzbd"  # noqa: no-relative-paths
-  ansible.builtin.include_tasks:
-    file: "{{ playbook_dir }}/../roles/backup/tasks/restore_service.yml"
+- name: "Restore sabnzbd"
+  ansible.builtin.include_role:
+    name: backup
+    tasks_from: restore_service
   vars:
-    _restore_label: sabnzbd
-    _restore_tmp_ext: tar.zst
-    _restore_service: sabnzbd
-    _restore_cmd: "zstd -d {{ backup_restore_file }} --stdout | tar -xf - -C {{ mms_config_dir }}/sabnzbd"
+    backup_restore_label: sabnzbd
+    backup_restore_tmp_ext: tar.zst
+    backup_restore_service: sabnzbd
+    backup_restore_cmd: "zstd -d {{ backup_restore_file }} --stdout | tar -xf - -C {{ mms_config_dir }}/sabnzbd"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-ansible-core>=2.20.0
+ansible-core>=2.18.12,<2.19
 ansible-lint>=24.0
 yamllint>=1.33
 molecule>=24.0

--- a/roles/backup/tasks/restore_service.yml
+++ b/roles/backup/tasks/restore_service.yml
@@ -1,44 +1,44 @@
 ---
 # Common restore task file, included via include_tasks with these vars:
-#   _restore_label   — identifier for temp file naming (e.g. "radarr", "immich-db")
-#   _restore_tmp_ext — temp file extension: "tar.zst" or "sql.zst"
-#   _restore_service — systemd user service to stop/start (empty string to skip)
-#   _restore_cmd     — shell command for extract/restore (may reference {{ backup_restore_file }})
+#   backup_restore_label   — identifier for temp file naming (e.g. "radarr", "immich-db")
+#   backup_restore_tmp_ext — temp file extension: "tar.zst" or "sql.zst"
+#   backup_restore_service — systemd user service to stop/start (empty string to skip)
+#   backup_restore_cmd     — shell command for extract/restore (may reference {{ backup_restore_file }})
 
-- name: "Stop service before restore — {{ _restore_label }}"
+- name: "Stop service before restore — {{ backup_restore_label }}"
   ansible.builtin.systemd:
-    name: "{{ _restore_service }}"
+    name: "{{ backup_restore_service }}"
     state: stopped
     scope: user
   environment: "{{ mms_systemd_env }}"
-  when: _restore_service | length > 0
+  when: backup_restore_service | length > 0
 
-- name: "Decrypt backup — {{ _restore_label }}"
+- name: "Decrypt backup — {{ backup_restore_label }}"
   ansible.builtin.command:
-    cmd: "age -d -i {{ backup_age_identity_file }} -o /tmp/restore-{{ _restore_label }}.{{ _restore_tmp_ext }} {{ backup_file }}"
+    cmd: "age -d -i {{ backup_age_identity_file }} -o /tmp/restore-{{ backup_restore_label }}.{{ backup_restore_tmp_ext }} {{ backup_file }}"
   changed_when: true
   when: backup_file is match('.*\.age$') and not ansible_check_mode
 
-- name: "Set restore file path — {{ _restore_label }}"
+- name: "Set restore file path — {{ backup_restore_label }}"
   ansible.builtin.set_fact:
-    backup_restore_file: "{{ '/tmp/restore-' + _restore_label + '.' + _restore_tmp_ext if backup_file is match('.*\\.age$') else backup_file }}"
+    backup_restore_file: "{{ '/tmp/restore-' + backup_restore_label + '.' + backup_restore_tmp_ext if backup_file is match('.*\\.age$') else backup_file }}"
 
-- name: "Restore data — {{ _restore_label }}"
+- name: "Restore data — {{ backup_restore_label }}"
   ansible.builtin.shell:  # noqa: command-instead-of-shell
-    cmd: "{{ _restore_cmd }}"
+    cmd: "{{ backup_restore_cmd }}"
   changed_when: true
   when: not ansible_check_mode
 
-- name: "Start service after restore — {{ _restore_label }}"
+- name: "Start service after restore — {{ backup_restore_label }}"
   ansible.builtin.systemd:
-    name: "{{ _restore_service }}"
+    name: "{{ backup_restore_service }}"
     state: started
     scope: user
   environment: "{{ mms_systemd_env }}"
-  when: _restore_service | length > 0
+  when: backup_restore_service | length > 0
 
-- name: "Clean up temp file — {{ _restore_label }}"
+- name: "Clean up temp file — {{ backup_restore_label }}"
   ansible.builtin.file:
-    path: "/tmp/restore-{{ _restore_label }}.{{ _restore_tmp_ext }}"
+    path: "/tmp/restore-{{ backup_restore_label }}.{{ backup_restore_tmp_ext }}"
     state: absent
   when: backup_file is match('.*\.age$')


### PR DESCRIPTION
## What

Two coupled changes:

1. **`requirements-dev.txt`**: `ansible-core` floor `>=2.20.0` → `>=2.18.12,<2.19`.
2. **Restore task includes**: replace the five `include_tasks: "{{ playbook_dir }}/../roles/backup/tasks/restore_service.yml"` references with `include_role: {name: backup, tasks_from: restore_service}`, and prefix the include parameters with `backup_` (`backup_restore_label`, etc.).

## Why

CI installs ansible-core via `pip install -r requirements-dev.txt`, so `>=2.20.0` ran lint and syntax checks against ansible-core 2.21, while production runs **2.18.12**:

- Host is Fedora 43; `dnf` provides 2.18.12 as the newest available, and the `base_system`/`autodeploy` roles install `ansible-core` via `dnf` (`state: present`), so the host cannot reach 2.20+ without bypassing the package manager.

Pinning to the 2.18 series makes CI test against the ansible-core that production actually runs. Doing so surfaced a latent fragility: the restore includes resolved `restore_service.yml` via `{{ playbook_dir }}/../`, which only works because `playbook_dir` stays at the top-level playbook dir at runtime. Under the 2.18 series, ansible-lint resolved `playbook_dir` to the included file's own directory and failed with a `load-failure`. `include_role` + `tasks_from` resolves via the role search path regardless of `playbook_dir`, so it is robust under any ansible-core and statically analyzable. The `backup_` prefix satisfies `var-naming` now that the parameters are passed into a role.

Verified: `ansible-lint` passes under both ansible-core 2.20.6 (local) and 2.18.17 (CI). The restore data path still needs an end-to-end test against a real backup before fully trusting the include_role change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)