### PR TITLE
fix(renovate): parse LinuxServer -ls build tags as version parts

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -73,6 +73,10 @@
       matchPackageNames: [
         '/^lscr\\.io/linuxserver//',
       ],
+      // LinuxServer tags are <version>[-ls<build>]; default docker versioning
+      // treats -ls<build> as an immutable compatibility suffix and never
+      // updates it. Parse the -ls build as a numeric version part instead.
+      versioning: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:\\.(?<build>\\d+))?(?:-ls(?<revision>\\d+))?$',
     },
     {
       description: 'Group Immich images',


### PR DESCRIPTION
## Problem

LinuxServer images with an `-ls<build>` suffix have been silently frozen by Renovate. `radarr` has shown `6.1.1.10360` in its GUI for weeks while the pinned tag stayed at `6.0.4.10291-ls291`. The same applies to `radarr4k`, `sonarr`, `prowlarr`, `lidarr`, and `sabnzbd`. Suffix-less LinuxServer images (`kometa`, `tautulli`) updated normally.

## Root cause

Renovate's default `docker` versioning splits a tag like `6.0.4.10291-ls291` into a version (`6.0.4.10291`) and a **compatibility** suffix (`-ls291`), and per its design *"a proposed update will never change the specified compatibility value"*. LinuxServer increments `-ls<build>` on every rebuild, so no newer tag ever shares the `-ls291` suffix and Renovate reports the image as up to date. The Dependency Dashboard (#28) showed no update annotation for any `-ls` image, and there has never been a Renovate PR for one.

The image source (`lscr.io` → `ghcr.io` via `registryAliases`) was never the issue.

## Fix

Add a `regex` versioning scheme to the existing "Group LinuxServer images" rule that captures the `-ls` build as a numeric version part:

```
regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:\.(?<build>\d+))?(?:-ls(?<revision>\d+))?$
```

This handles all three tag shapes in the stack: 4-part + `-ls` (radarr/sonarr/prowlarr/lidarr), 3-part + `-ls` (sabnzbd), and plain semver (kometa/tautulli).

## Verification

- `renovate-config-validator` (Renovate 43.216.1): config valid.
- Local dry-run (`--platform=local --dry-run=lookup`) now detects updates for every previously-stuck image:

| Service | Old | New | Type |
|---|---|---|---|
| radarr / radarr4k | `6.0.4.10291-ls291` | `6.1.1.10360-ls304` | minor |
| sonarr | `4.0.16.2944-ls301` | `4.0.17.2952-ls313` | patch |
| prowlarr | `2.3.0.5236-ls136` | `2.3.5.5327-ls148` | patch |
| lidarr | `3.1.0.4875-ls19` | `3.1.0.4875-ls30` | patch |
| sabnzbd | `4.5.5-ls243` | `5.0.3-ls257` | major |

radarr's `6.1.1.10360` matches the version reported in the GUI. Update-type classification is correct: minor/patch updates automerge under the existing rule; sabnzbd's major bump is gated and labeled `major-update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)