### PR TITLE
chore(sabnzbd): upgrade image to 5.0.4-ls261

### DIFF
--- a/services/sabnzbd.yml
+++ b/services/sabnzbd.yml
@@ -2,7 +2,7 @@
 sabnzbd:
   name: sabnzbd
   description: "SABnzbd - Usenet Downloader"
-  image: "lscr.io/linuxserver/sabnzbd:4.5.5-ls243"
+  image: "lscr.io/linuxserver/sabnzbd:5.0.4-ls261"
   volumes:
     - "{{ mms_config_dir }}/sabnzbd:/config:Z"
     - "{{ mms_data_dir }}:/data"


### PR DESCRIPTION
Bumps SABnzbd from `4.5.5-ls243` to `5.0.4-ls261` (LinuxServer current latest) — a 4.x → 5.x major bump.

## Change
- `services/sabnzbd.yml`: image tag `4.5.5-ls243` → `5.0.4-ls261`

## Compatibility
SABnzbd 5.0 breaking changes do not affect this deployment:

| SABnzbd 5.0 change | Impact |
|---|---|
| Dropped Python 3.8 | None — Python is bundled in the LSIO image |
| Removed `empty_postproc` setting | Not in our `ini_settings` |
| Post-proc scripts run on failed jobs too | No post-proc scripts defined |
| `host_whitelist` / `api?mode=version` | Unchanged — INI setting and healthcheck still valid |

## Verification
- Confirmed `5.0.4-ls261` exists in the GHCR registry (LinuxServer current latest).
- No other `4.5.5` references remain in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)