### PR TITLE
ci: pin GitHub Actions to commit SHAs and add zizmor to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
 
+      - name: Run zizmor
+        run: zizmor --min-severity high .github/workflows/
+
       - name: Install Galaxy collections
         run: ansible-galaxy collection install -r requirements.yml
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,12 +8,17 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.13"
 

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -15,10 +15,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout main repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Checkout wiki repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ github.repository }}.wiki
           path: wiki-checkout

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -16,8 +16,17 @@ jobs:
     steps:
       - name: Checkout main repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # This checkout is only read from (docs/wiki is copied out of it),
+          # so it needs no credentials left behind in .git/config.
+          persist-credentials: false
 
-      - name: Checkout wiki repo
+      # Do NOT set persist-credentials: false here. The "Commit and push wiki
+      # changes" step below runs `git push` from wiki-checkout and relies on
+      # WIKI_TOKEN being persisted in its .git/config by this step. zizmor
+      # flags this as `artipacked` and offers it as an unsafe auto-fix --
+      # applying that fix breaks the wiki sync.
+      - name: Checkout wiki repo # zizmor: ignore[artipacked]
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ github.repository }}.wiki

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,17 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
@@ -37,6 +42,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.13"
 
@@ -36,10 +36,10 @@ jobs:
         role: [base_system, open_notebook, quadlet_service, traefik]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.13"
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -213,9 +213,9 @@
         "filename": "roles/open_notebook/molecule/default/molecule.yml",
         "hashed_secret": "34a5715a027d52e27dbb1dc429958ca78b5e78f9",
         "is_verified": false,
-        "line_number": 28
+        "line_number": 39
       }
     ]
   },
-  "generated_at": "2026-05-18T13:24:54Z"
+  "generated_at": "2026-07-28T22:30:17Z"
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,6 +2,7 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
     'config:recommended',
+    'helpers:pinGitHubActionDigests',
   ],
   schedule: [
     'before 6am on Monday',

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,6 @@ pre-commit>=3.0
 proxmoxer>=2.3.0
 requests>=2.30
 pytest==9.1.1
+# Pinned exactly so a new release cannot turn a fresh audit rule into a
+# surprise CI failure; renovate proposes bumps as reviewable PRs.
+zizmor==1.28.0


### PR DESCRIPTION
Pins every GitHub Actions reference to a commit SHA and adds a zizmor gate to CI.

Closes #124

## Changes

**Pin actions to commit SHAs.** All 8 references to `actions/checkout` and
`actions/setup-python` across `lint.yml`, `test.yml`, and `sync-wiki.yml` move
from the mutable `@v7` major tag to a full commit SHA with a trailing `# v7`
comment:

| Action | SHA |
| --- | --- |
| `actions/checkout` | `3d3c42e5aac5ba805825da76410c181273ba90b1` |
| `actions/setup-python` | `5fda3b95a4ea91299a34e894583c3862153e4b97` |

**Renovate keeps digests current.** `helpers:pinGitHubActionDigests` is added to
`extends` in `renovate.json5`. The existing automerge rule already lists
`digest` in `matchUpdateTypes`, so digest refreshes merge without review burden.

**zizmor runs in CI.** `zizmor==1.28.0` is added to `requirements-dev.txt`, which
the lint job already installs, and the lint job gains a
`zizmor --min-severity high .github/workflows/` step that fails the build on
High-severity findings. Installing via pip rather than a marketplace action
avoids introducing another action dependency to pin, and keeps local runs on the
same version as CI. The exact pin means a new zizmor release cannot turn a fresh
audit rule into an unrelated CI failure; Renovate proposes bumps as PRs.

**Least-privilege permissions.** `lint.yml` and `test.yml` had no `permissions:`
block and inherited the default token scope. Both now declare workflow-level
`contents: read`.

**Credential persistence.** `persist-credentials: false` is set on the four
checkouts that only read.

The wiki checkout in `sync-wiki.yml` is deliberately left persisting its
credentials: the `git push` step relies on `WIKI_TOKEN` being written to that
checkout's `.git/config`. Setting `persist-credentials: false` there — which
zizmor offers as an auto-fix — would break the wiki sync. The step carries a
comment explaining this and a `# zizmor: ignore[artipacked]` marker so the
auto-fix is not applied later.

## Also included

`.secrets.baseline` recorded the open_notebook molecule test password at line 28;
it has been at line 39 for some time, so `prek run --all-files` failed on `main`
before this branch. The baseline is refreshed. No new secrets are baselined —
the diff is one line number and the timestamp.

## Verification

Run locally on the branch head, each checked by exit code:

| Check | Result |
| --- | --- |
| `zizmor .github/workflows/` | 0 findings at every severity |
| `zizmor --min-severity high .github/workflows/` | pass (the CI invocation) |
| `actionlint` | pass |
| `make lint` | pass |
| `.venv/bin/pytest` | pass (29 tests) |
| `prek run --all-files` | pass |

zizmor on `main` reported 8 High (`unpinned-uses`), 4 Medium
(`excessive-permissions`), and 5 Low (`artipacked`). All 17 are resolved; the one
remaining finding is the intentional wiki-checkout `artipacked`, explicitly
ignored.

Checked that nothing depended on what was removed: neither `lint.yml` nor
`test.yml` runs any git operation, `requirements.yml` sources no collections over
SCM, and Molecule pulls `fedora:43` from Docker Hub rather than GHCR, so no
`packages:read` scope is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
