### PR TITLE
ci: cache pip and Ansible Galaxy dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,12 +24,22 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
 
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
 
       - name: Run zizmor
         run: zizmor --min-severity high .github/workflows/
+
+      - name: Cache Galaxy collections
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.ansible/collections
+          key: ${{ runner.os }}-galaxy-${{ hashFiles('requirements.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-galaxy-
 
       - name: Install Galaxy collections
         run: ansible-galaxy collection install -r requirements.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
 
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
@@ -49,9 +51,21 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
 
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
+
+      # Key is deliberately not matrix-dependent: all four legs install the
+      # same requirements.yml and share one cache entry.
+      - name: Cache Galaxy collections
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.ansible/collections
+          key: ${{ runner.os }}-galaxy-${{ hashFiles('requirements.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-galaxy-
 
       - name: Install Galaxy collections
         run: ansible-galaxy collection install -r requirements.yml


### PR DESCRIPTION
Adds dependency caching to the CI workflows.

## What this does

- `cache: pip` with `cache-dependency-path: requirements-dev.txt` on all three
  `actions/setup-python` steps (lint, pytest, molecule). All three jobs install
  from the same file, so one dependency path covers them.
- An `actions/cache` step for `~/.ansible/collections`, keyed on a hash of
  `requirements.yml`, in the two jobs that run `ansible-galaxy collection
  install` (lint and molecule). The pip cache does not cover Galaxy collections.
  The `pytest` job does not install collections and does not get this step.

The new `actions/cache` ref is pinned to a full commit SHA (`v6` →
`55cc8345863c7cc4c66a329aec7e433d2d1c52a9`) to satisfy the zizmor
`unpinned-uses` gate added in #124.

## Notes

- The molecule job is a four-leg matrix. The cache key is deliberately not
  matrix-dependent — all four legs install the same `requirements.yml` and share
  one entry. Concurrent saves produce an `actions/cache` warning, not a failure.
- `ansible-galaxy collection install` runs unconditionally rather than being
  gated on `cache-hit`, so a partial or stale cache is reconciled against
  `requirements.yml` on every run. Verified locally that installing over a
  different pinned version overwrites correctly in both the upgrade and
  downgrade direction.
- `cache: pip` caches pip's download cache, not installed packages — `pip
  install` still resolves and installs each run, so the saving is download time
  only. Expect the first run on this branch to be a cache miss.

Closes #125